### PR TITLE
fix: reduce @Property(tries) on compilation-heavy test classes

### DIFF
--- a/.kiro/specs/slow-tests-fix/.config.kiro
+++ b/.kiro/specs/slow-tests-fix/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "c0de2df2-45d4-4b24-a0a5-d677c43b48ef", "workflowType": "requirements-first", "specType": "bugfix"}

--- a/.kiro/specs/slow-tests-fix/bugfix.md
+++ b/.kiro/specs/slow-tests-fix/bugfix.md
@@ -1,0 +1,74 @@
+# Bugfix Requirements Document
+
+## Introduction
+
+Several property-based tests (jqwik) in the test suite invoke `javax.tools.JavaCompiler` on every
+single try. Because compilation is expensive (JVM startup, disk I/O, class loading), tests that
+run 100 tries × full compilation per try dominate total test time and make the inner dev loop with
+Kiro noticeably slow.
+
+The affected tests are:
+
+- `ElementValidatorPropertyTest` — 9 properties × 100 tries, each spawning a full compiler
+  invocation with the annotation processor active.
+- `BytecodeInjectorPropertyTest` — 5 properties × 100 tries, each compiling a fresh `.java`
+  source file to produce a `.class` file for injection.
+- `RawitAnnotationProcessorPropertyTest` — 3 properties × 10 tries, each running a 3-pass
+  compilation pipeline (proc-only + generated-source compile + class load).
+- `RawitAnnotationProcessorConstructorPropertyTest` — 3 properties × 10 tries, same 3-pass
+  pipeline.
+
+The pure in-memory tests (`InvokerClassSpecPropertyTest`, `StageInterfaceSpecPropertyTest`,
+`TerminalInterfaceSpecPropertyTest`, `MergeTreeBuilderPropertyTest`) are already fast and are
+not affected.
+
+## Bug Analysis
+
+### Current Behavior (Defect)
+
+1.1 WHEN `ElementValidatorPropertyTest` runs THEN the system invokes `JavaCompiler` once per
+    try (100 tries × 9 properties = up to 900 compiler invocations), making the test class
+    take tens of seconds.
+
+1.2 WHEN `BytecodeInjectorPropertyTest` runs THEN the system compiles a fresh `.java` source
+    file on every try (100 tries × 5 properties = up to 500 compiler invocations), making the
+    test class take tens of seconds.
+
+1.3 WHEN `RawitAnnotationProcessorPropertyTest` runs THEN the system runs a 3-pass compilation
+    pipeline on every try (10 tries × 3 properties = 30 full pipelines), each pipeline being
+    significantly more expensive than a single compilation.
+
+1.4 WHEN `RawitAnnotationProcessorConstructorPropertyTest` runs THEN the system runs a 3-pass
+    compilation pipeline on every try (10 tries × 3 properties = 30 full pipelines).
+
+### Expected Behavior (Correct)
+
+2.1 WHEN `ElementValidatorPropertyTest` runs THEN the system SHALL reduce the number of
+    compiler invocations by lowering the `tries` count to 5 without sacrificing correctness.
+
+2.2 WHEN `BytecodeInjectorPropertyTest` runs THEN the system SHALL reduce the number of
+    compiler invocations by lowering the `tries` count to 5 without sacrificing correctness.
+
+2.3 WHEN `RawitAnnotationProcessorPropertyTest` runs THEN the system SHALL reduce the number
+    of full compilation pipelines by lowering the `tries` count to 5, since each try
+    is already a heavyweight end-to-end integration scenario.
+
+2.4 WHEN `RawitAnnotationProcessorConstructorPropertyTest` runs THEN the system SHALL reduce
+    the number of full compilation pipelines by lowering the `tries` count to 5.
+
+### Unchanged Behavior (Regression Prevention)
+
+3.1 WHEN any property test runs THEN the system SHALL CONTINUE TO execute at least one try
+    per property, ensuring every property is still exercised.
+
+3.2 WHEN the pure in-memory property tests run (`InvokerClassSpecPropertyTest`,
+    `StageInterfaceSpecPropertyTest`, `TerminalInterfaceSpecPropertyTest`,
+    `MergeTreeBuilderPropertyTest`) THEN the system SHALL CONTINUE TO run those tests at
+    100 tries, since they are already fast.
+
+3.3 WHEN a property test detects a violation THEN the system SHALL CONTINUE TO report a
+    clear failure with the counterexample, regardless of the reduced try count.
+
+3.4 WHEN the full test suite runs THEN the system SHALL CONTINUE TO cover all existing
+    acceptance criteria (validation rules, bytecode injection correctness, end-to-end
+    annotation processing).

--- a/.kiro/specs/slow-tests-fix/design.md
+++ b/.kiro/specs/slow-tests-fix/design.md
@@ -1,0 +1,248 @@
+# Slow Tests Fix — Bugfix Design
+
+## Overview
+
+Four jqwik property-test classes invoke `javax.tools.JavaCompiler` (or a full 3-pass compilation
+pipeline) on every single try. Because compilation is expensive, these classes dominate total test
+time. The fix is a targeted reduction of the `@Property(tries = …)` value on each affected class
+while leaving the pure in-memory property tests untouched.
+
+Affected classes and their new `tries` values:
+
+| Class | Old tries | New tries |
+|---|---|---|
+| `ElementValidatorPropertyTest` | 100 | 5 |
+| `BytecodeInjectorPropertyTest` | 100 | 5 |
+| `RawitAnnotationProcessorPropertyTest` | 10 | 5 |
+| `RawitAnnotationProcessorConstructorPropertyTest` | 10 | 5 |
+
+Unaffected (pure in-memory, stay at 100):
+`InvokerClassSpecPropertyTest`, `StageInterfaceSpecPropertyTest`,
+`TerminalInterfaceSpecPropertyTest`, `MergeTreeBuilderPropertyTest`.
+
+## Glossary
+
+- **Bug_Condition (C)**: The condition that triggers the performance problem — a property-test
+  class that invokes `JavaCompiler` (or a multi-pass compilation pipeline) on every try AND has
+  a `tries` count that is higher than necessary for meaningful coverage.
+- **Property (P)**: The desired state after the fix — the `tries` count is reduced to a value
+  that still exercises the property meaningfully but avoids unnecessary compiler invocations.
+- **Preservation**: The `tries` count on pure in-memory property tests must remain unchanged,
+  and every property must still be executed at least once.
+- **`@Property(tries = N)`**: The jqwik annotation attribute that controls how many random
+  inputs are generated per property method.
+- **compilation-heavy test**: A property test whose body calls `ToolProvider.getSystemJavaCompiler()`
+  or a multi-pass pipeline (proc-only + generated-source compile + class load) on every try.
+- **pure in-memory test**: A property test that operates entirely on in-memory data structures
+  (no `JavaCompiler` calls), making 100 tries cheap.
+
+## Bug Details
+
+### Bug Condition
+
+The bug manifests when a property-test class that invokes `JavaCompiler` on every try is
+configured with a `tries` count that is unnecessarily high. The `@Property(tries = N)`
+annotation on each affected method is set to a value that causes hundreds (or tens) of
+full compiler invocations per test run, making the suite slow.
+
+**Formal Specification:**
+```
+FUNCTION isBugCondition(testClass)
+  INPUT: testClass — a jqwik property-test class
+  OUTPUT: boolean
+
+  RETURN testClass.invokesJavaCompilerPerTry = true
+         AND testClass.triesCount > THRESHOLD(testClass)
+         
+  WHERE THRESHOLD(testClass) = 5   -- all compilation-heavy tests
+END FUNCTION
+```
+
+### Examples
+
+- `ElementValidatorPropertyTest` with `tries = 100`: 9 properties × 100 tries × 1 compiler
+  invocation = up to 900 compiler calls. **Expected**: `tries = 5` → up to 45 calls.
+- `BytecodeInjectorPropertyTest` with `tries = 100`: 5 properties × 100 tries × 1 compiler
+  invocation = up to 500 compiler calls. **Expected**: `tries = 5` → up to 25 calls.
+- `RawitAnnotationProcessorPropertyTest` with `tries = 10`: 3 properties × 10 tries × 3-pass
+  pipeline = 30 full pipelines. **Expected**: `tries = 5` → 15 full pipelines.
+- `RawitAnnotationProcessorConstructorPropertyTest` with `tries = 10`: same as above.
+- `MergeTreeBuilderPropertyTest` with `tries = 100`: pure in-memory, no compiler calls.
+  **Expected**: stays at 100 — no change needed.
+
+## Expected Behavior
+
+### Preservation Requirements
+
+**Unchanged Behaviors:**
+- Pure in-memory property tests (`InvokerClassSpecPropertyTest`, `StageInterfaceSpecPropertyTest`,
+  `TerminalInterfaceSpecPropertyTest`, `MergeTreeBuilderPropertyTest`) must continue to run at
+  100 tries.
+- Every property in every affected class must still be executed (at least 1 try per property).
+- When a property detects a violation, jqwik must still report a clear failure with the
+  counterexample, regardless of the reduced try count.
+- The full test suite must continue to cover all existing acceptance criteria.
+
+**Scope:**
+All inputs that do NOT involve the `tries` attribute of a compilation-heavy property test are
+completely unaffected by this fix. This includes:
+- The test logic itself (assertions, arbitraries, helper methods)
+- The production source files under `src/main/`
+- Any non-property tests (unit tests, integration tests)
+- The `tries` values on pure in-memory property tests
+
+## Hypothesized Root Cause
+
+The `tries` counts were set to their current values when the tests were first written, likely
+mirroring the default jqwik value of 1000 (reduced to 100 as a first pass) without accounting
+for the per-try cost of invoking `JavaCompiler`. The root cause is simply that the annotation
+`@Property(tries = 100)` (or `tries = 10`) was applied uniformly without distinguishing between
+cheap in-memory tests and expensive compilation-based tests.
+
+1. **Uniform tries count**: All property tests were given the same `tries` value regardless of
+   per-try cost. Compilation-heavy tests need a lower value.
+
+2. **No per-class cost model**: There is no mechanism in the codebase to enforce different
+   `tries` budgets for different cost tiers of tests.
+
+3. **Incremental growth**: As more compilation-heavy properties were added, the cumulative
+   cost grew but the `tries` values were never revisited.
+
+## Correctness Properties
+
+Property 1: Bug Condition — Compilation-Heavy Tests Use Reduced Tries
+
+_For any_ property-test class where the bug condition holds (invokes `JavaCompiler` per try
+AND current `tries` exceeds the threshold), the fixed class SHALL have its `@Property(tries = N)`
+reduced to 5.
+
+**Validates: Requirements 2.1, 2.2, 2.3, 2.4**
+
+Property 2: Preservation — Pure In-Memory Tests and Test Logic Are Unchanged
+
+_For any_ property-test class where the bug condition does NOT hold (either pure in-memory OR
+already at/below the threshold), the fixed codebase SHALL leave the `tries` count and all test
+logic identical to the original, preserving full coverage for fast tests.
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4**
+
+## Fix Implementation
+
+### Changes Required
+
+Assuming our root cause analysis is correct, the fix is four targeted annotation-attribute edits.
+
+**File**: `src/test/java/rawit/processors/validation/ElementValidatorPropertyTest.java`
+
+**Change**: Replace every `@Property(tries = 100)` with `@Property(tries = 5)`.
+There are 9 such annotations (one per property method in the class).
+
+---
+
+**File**: `src/test/java/rawit/processors/inject/BytecodeInjectorPropertyTest.java`
+
+**Change**: Replace every `@Property(tries = 100)` with `@Property(tries = 5)`.
+There are 5 such annotations (one per property method in the class).
+
+---
+
+**File**: `src/test/java/rawit/processors/RawitAnnotationProcessorPropertyTest.java`
+
+**Change**: Replace every `@Property(tries = 10)` with `@Property(tries = 5)`.
+There are 3 such annotations (one per property method in the class).
+
+---
+
+**File**: `src/test/java/rawit/processors/RawitAnnotationProcessorConstructorPropertyTest.java`
+
+**Change**: Replace every `@Property(tries = 10)` with `@Property(tries = 5)`.
+There are 3 such annotations (one per property method in the class).
+
+**No other files are modified.**
+
+## Testing Strategy
+
+### Validation Approach
+
+The testing strategy follows a two-phase approach: first, confirm the current slow behavior
+(exploratory), then verify the fix reduces tries counts without breaking any test logic.
+
+### Exploratory Bug Condition Checking
+
+**Goal**: Surface counterexamples that demonstrate the bug BEFORE implementing the fix.
+Confirm or refute the root cause analysis.
+
+**Test Plan**: Inspect the `@Property(tries = N)` annotations in each affected class and
+assert that the current value exceeds the threshold. Run the test suite and observe that
+compilation-heavy classes take disproportionately long.
+
+**Test Cases**:
+1. **ElementValidatorPropertyTest tries check**: Assert `tries = 100` on all 9 properties
+   (will fail after fix, confirming the fix was applied).
+2. **BytecodeInjectorPropertyTest tries check**: Assert `tries = 100` on all 5 properties.
+3. **RawitAnnotationProcessorPropertyTest tries check**: Assert `tries = 10` on all 3 properties.
+4. **RawitAnnotationProcessorConstructorPropertyTest tries check**: Assert `tries = 10` on all 3 properties.
+
+**Expected Counterexamples**:
+- The `tries` attribute on compilation-heavy properties is higher than the threshold.
+- Possible causes: uniform tries policy, no cost-tier distinction.
+
+### Fix Checking
+
+**Goal**: Verify that for all inputs where the bug condition holds, the fixed annotation
+attribute equals the threshold value.
+
+**Pseudocode:**
+```
+FOR ALL testClass WHERE isBugCondition(testClass) DO
+  result := inspect @Property(tries) on each method in testClass
+  ASSERT result = THRESHOLD(testClass)
+END FOR
+```
+
+### Preservation Checking
+
+**Goal**: Verify that for all inputs where the bug condition does NOT hold, the fixed
+codebase produces the same result as the original.
+
+**Pseudocode:**
+```
+FOR ALL testClass WHERE NOT isBugCondition(testClass) DO
+  ASSERT @Property(tries) in fixed = @Property(tries) in original
+  ASSERT test logic in fixed = test logic in original
+END FOR
+```
+
+**Testing Approach**: Property-based testing is recommended for preservation checking because:
+- It generates many test cases automatically across the input domain.
+- It catches edge cases that manual unit tests might miss.
+- It provides strong guarantees that behavior is unchanged for all non-buggy inputs.
+
+**Test Plan**: Observe that pure in-memory tests still pass at 100 tries after the fix.
+
+**Test Cases**:
+1. **MergeTreeBuilderPropertyTest preservation**: Verify `tries = 100` is unchanged and all
+   properties still pass.
+2. **InvokerClassSpecPropertyTest preservation**: Verify `tries = 100` is unchanged.
+3. **StageInterfaceSpecPropertyTest preservation**: Verify `tries = 100` is unchanged.
+4. **TerminalInterfaceSpecPropertyTest preservation**: Verify `tries = 100` is unchanged.
+
+### Unit Tests
+
+- Verify each affected class has the correct reduced `tries` value after the fix.
+- Verify each unaffected class retains its original `tries` value.
+- Verify that all property methods in affected classes still compile and run without errors.
+
+### Property-Based Tests
+
+- Generate random valid inputs for each affected property and verify the property still holds
+  with the reduced tries count (i.e., no regressions in the test logic itself).
+- Verify that the pure in-memory properties continue to pass across 100 tries.
+- Verify that jqwik still reports counterexamples correctly when a property is violated.
+
+### Integration Tests
+
+- Run the full test suite after the fix and verify all tests pass.
+- Measure total test time before and after to confirm a meaningful reduction.
+- Verify that switching between compilation-heavy and in-memory tests in the same run
+  produces correct results for both.

--- a/.kiro/specs/slow-tests-fix/tasks.md
+++ b/.kiro/specs/slow-tests-fix/tasks.md
@@ -1,0 +1,88 @@
+# Implementation Plan
+
+- [x] 1. Write bug condition exploration test
+  - **Property 1: Bug Condition** - Compilation-Heavy Tests Use Excessive Tries
+  - **CRITICAL**: This test MUST FAIL on unfixed code — failure confirms the bug exists
+  - **DO NOT attempt to fix the test or the code when it fails**
+  - **NOTE**: This test encodes the expected behavior — it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples that demonstrate the bug exists
+  - **Scoped PBT Approach**: Scope the property to the four concrete affected classes for reproducibility
+  - For each affected class, read the `@Property(tries = N)` annotation value on every property method using reflection or source inspection
+  - Assert that `ElementValidatorPropertyTest` has `tries = 5` on all 9 property methods (will FAIL — currently 100)
+  - Assert that `BytecodeInjectorPropertyTest` has `tries = 5` on all 5 property methods (will FAIL — currently 100)
+  - Assert that `RawitAnnotationProcessorPropertyTest` has `tries = 5` on all 3 property methods (will FAIL — currently 10)
+  - Assert that `RawitAnnotationProcessorConstructorPropertyTest` has `tries = 5` on all 3 property methods (will FAIL — currently 10)
+  - Run test on UNFIXED code
+  - **EXPECTED OUTCOME**: Test FAILS (this is correct — it proves the bug exists)
+  - Document counterexamples found: e.g. `ElementValidatorPropertyTest.property1_validInvokerMethod_producesNoErrors` has `tries=100` instead of `tries=5`
+  - Mark task complete when test is written, run, and failure is documented
+  - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+- [x] 2. Write preservation property tests (BEFORE implementing fix)
+  - **Property 2: Preservation** - Pure In-Memory Tests Retain tries=100
+  - **IMPORTANT**: Follow observation-first methodology
+  - Observe: `MergeTreeBuilderPropertyTest` has `tries = 100` on all properties on unfixed code
+  - Observe: `InvokerClassSpecPropertyTest` has `tries = 100` on all properties on unfixed code
+  - Observe: `StageInterfaceSpecPropertyTest` has `tries = 100` on all properties on unfixed code
+  - Observe: `TerminalInterfaceSpecPropertyTest` has `tries = 100` on all properties on unfixed code
+  - Write property-based test: for all pure in-memory property test classes (isBugCondition = false), the `tries` value equals 100
+  - Also verify test logic (assertions, arbitraries, helper methods) in affected classes is unchanged — only the annotation attribute differs
+  - Run tests on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.1, 3.2, 3.3, 3.4_
+
+- [x] 3. Fix: reduce @Property(tries) on compilation-heavy test classes
+
+  - [x] 3.1 Implement the fix in ElementValidatorPropertyTest
+    - Replace all 9 occurrences of `@Property(tries = 100)` with `@Property(tries = 5)` in `src/test/java/rawit/processors/validation/ElementValidatorPropertyTest.java`
+    - No other changes to the file (test logic, assertions, arbitraries, helpers all unchanged)
+    - _Bug_Condition: isBugCondition(testClass) where testClass.invokesJavaCompilerPerTry = true AND testClass.triesCount > 5_
+    - _Expected_Behavior: @Property(tries = 5) on all 9 property methods_
+    - _Preservation: test logic, assertions, and arbitraries remain identical_
+    - _Requirements: 2.1, 3.1, 3.3, 3.4_
+
+  - [x] 3.2 Implement the fix in BytecodeInjectorPropertyTest
+    - Replace all 5 occurrences of `@Property(tries = 100)` with `@Property(tries = 5)` in `src/test/java/rawit/processors/inject/BytecodeInjectorPropertyTest.java`
+    - No other changes to the file
+    - _Bug_Condition: isBugCondition(testClass) where testClass.invokesJavaCompilerPerTry = true AND testClass.triesCount > 5_
+    - _Expected_Behavior: @Property(tries = 5) on all 5 property methods_
+    - _Preservation: test logic, assertions, and arbitraries remain identical_
+    - _Requirements: 2.2, 3.1, 3.3, 3.4_
+
+  - [x] 3.3 Implement the fix in RawitAnnotationProcessorPropertyTest
+    - Replace all 3 occurrences of `@Property(tries = 10)` with `@Property(tries = 5)` in `src/test/java/rawit/processors/RawitAnnotationProcessorPropertyTest.java`
+    - No other changes to the file
+    - _Bug_Condition: isBugCondition(testClass) where testClass.invokesJavaCompilerPerTry = true AND testClass.triesCount > 5_
+    - _Expected_Behavior: @Property(tries = 5) on all 3 property methods_
+    - _Preservation: test logic, assertions, and arbitraries remain identical_
+    - _Requirements: 2.3, 3.1, 3.3, 3.4_
+
+  - [x] 3.4 Implement the fix in RawitAnnotationProcessorConstructorPropertyTest
+    - Replace all 3 occurrences of `@Property(tries = 10)` with `@Property(tries = 5)` in `src/test/java/rawit/processors/RawitAnnotationProcessorConstructorPropertyTest.java`
+    - No other changes to the file
+    - _Bug_Condition: isBugCondition(testClass) where testClass.invokesJavaCompilerPerTry = true AND testClass.triesCount > 5_
+    - _Expected_Behavior: @Property(tries = 5) on all 3 property methods_
+    - _Preservation: test logic, assertions, and arbitraries remain identical_
+    - _Requirements: 2.4, 3.1, 3.3, 3.4_
+
+  - [x] 3.5 Verify bug condition exploration test now passes
+    - **Property 1: Expected Behavior** - Compilation-Heavy Tests Use Reduced Tries
+    - **IMPORTANT**: Re-run the SAME test from task 1 — do NOT write a new test
+    - The test from task 1 encodes the expected behavior (tries = 5 on all affected methods)
+    - Run bug condition exploration test from step 1
+    - **EXPECTED OUTCOME**: Test PASSES (confirms bug is fixed — all 20 affected annotations now read tries=5)
+    - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+  - [x] 3.6 Verify preservation tests still pass
+    - **Property 2: Preservation** - Pure In-Memory Tests Retain tries=100
+    - **IMPORTANT**: Re-run the SAME tests from task 2 — do NOT write new tests
+    - Run preservation property tests from step 2
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions — pure in-memory tests still at 100 tries)
+    - Confirm all tests still pass after fix (no regressions)
+
+- [x] 4. Checkpoint — Ensure all tests pass
+  - Run the full test suite (`mvn test`) and verify all tests pass
+  - Confirm compilation-heavy property tests still exercise their properties (at least 1 try each)
+  - Confirm pure in-memory property tests still run at 100 tries
+  - Ask the user if any questions arise

--- a/src/test/java/rawit/SlowTestsBugConditionExplorationTest.java
+++ b/src/test/java/rawit/SlowTestsBugConditionExplorationTest.java
@@ -1,0 +1,129 @@
+package rawit;
+
+import net.jqwik.api.Property;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Bug condition exploration test for the slow-tests-fix bugfix spec.
+ *
+ * <p>Validates: Requirements 2.1, 2.2, 2.3, 2.4
+ *
+ * <p>This test asserts the EXPECTED (fixed) values — it will FAIL on unfixed code,
+ * confirming the bug exists. When the fix is applied, this test will pass.
+ *
+ * <p>Uses reflection to read the {@code @Property(tries = N)} annotation on every
+ * {@code @Property}-annotated method in the four affected classes.
+ */
+class SlowTestsBugConditionExplorationTest {
+
+    private static final int EXPECTED_TRIES = 5;
+
+    /**
+     * Collects all methods annotated with {@code @Property} in the given class
+     * and returns a list of violations where {@code tries != expectedTries}.
+     */
+    private List<String> findViolations(Class<?> testClass, int expectedTries) {
+        List<String> violations = new ArrayList<>();
+        for (Method method : testClass.getDeclaredMethods()) {
+            Property annotation = method.getAnnotation(Property.class);
+            if (annotation != null) {
+                int actual = annotation.tries();
+                if (actual != expectedTries) {
+                    violations.add(testClass.getSimpleName() + "#" + method.getName()
+                            + ": tries=" + actual + " (expected " + expectedTries + ")");
+                }
+            }
+        }
+        return violations;
+    }
+
+    /**
+     * Asserts that every {@code @Property} method in the given class has exactly
+     * {@code expectedTries} tries, and that the class has exactly {@code expectedCount}
+     * property methods.
+     */
+    private void assertTriesAndCount(Class<?> testClass, int expectedTries, int expectedCount) {
+        long propertyMethodCount = Arrays.stream(testClass.getDeclaredMethods())
+                .filter(m -> m.isAnnotationPresent(Property.class))
+                .count();
+
+        assertEquals(expectedCount, propertyMethodCount,
+                testClass.getSimpleName() + " must have exactly " + expectedCount
+                        + " @Property methods, found " + propertyMethodCount);
+
+        List<String> violations = findViolations(testClass, expectedTries);
+        if (!violations.isEmpty()) {
+            fail("Found @Property methods with tries != " + expectedTries
+                    + " in " + testClass.getSimpleName() + ":\n  "
+                    + String.join("\n  ", violations));
+        }
+    }
+
+    private static Class<?> loadClass(String name) {
+        try {
+            return Class.forName(name);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Could not load class: " + name, e);
+        }
+    }
+
+    /**
+     * Validates: Requirements 2.1
+     *
+     * <p>Asserts that all 9 property methods in {@code ElementValidatorPropertyTest}
+     * have {@code tries = 5}. FAILS on unfixed code (currently tries=100).
+     */
+    @Test
+    void elementValidatorPropertyTest_allPropertiesHaveTries5() {
+        assertTriesAndCount(
+                loadClass("rawit.processors.validation.ElementValidatorPropertyTest"),
+                EXPECTED_TRIES, 9);
+    }
+
+    /**
+     * Validates: Requirements 2.2
+     *
+     * <p>Asserts that all 5 property methods in {@code BytecodeInjectorPropertyTest}
+     * have {@code tries = 5}. FAILS on unfixed code (currently tries=100).
+     */
+    @Test
+    void bytecodeInjectorPropertyTest_allPropertiesHaveTries5() {
+        assertTriesAndCount(
+                loadClass("rawit.processors.inject.BytecodeInjectorPropertyTest"),
+                EXPECTED_TRIES, 5);
+    }
+
+    /**
+     * Validates: Requirements 2.3
+     *
+     * <p>Asserts that all 3 property methods in {@code RawitAnnotationProcessorPropertyTest}
+     * have {@code tries = 5}. FAILS on unfixed code (currently tries=10).
+     */
+    @Test
+    void rawitAnnotationProcessorPropertyTest_allPropertiesHaveTries5() {
+        assertTriesAndCount(
+                loadClass("rawit.processors.RawitAnnotationProcessorPropertyTest"),
+                EXPECTED_TRIES, 3);
+    }
+
+    /**
+     * Validates: Requirements 2.4
+     *
+     * <p>Asserts that all 3 property methods in {@code RawitAnnotationProcessorConstructorPropertyTest}
+     * have {@code tries = 5}. FAILS on unfixed code (currently tries=10).
+     */
+    @Test
+    void rawitAnnotationProcessorConstructorPropertyTest_allPropertiesHaveTries5() {
+        assertTriesAndCount(
+                loadClass("rawit.processors.RawitAnnotationProcessorConstructorPropertyTest"),
+                EXPECTED_TRIES, 3);
+    }
+}

--- a/src/test/java/rawit/SlowTestsPreservationTest.java
+++ b/src/test/java/rawit/SlowTestsPreservationTest.java
@@ -1,0 +1,76 @@
+package rawit;
+
+import net.jqwik.api.Property;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Preservation test: verifies that the four pure in-memory property test classes
+ * still have {@code tries = 100} on all their {@code @Property} methods.
+ *
+ * <p>This is a plain JUnit 5 test that inspects annotations via reflection.
+ * It is NOT a jqwik property test itself.
+ *
+ * <p>Validates: Requirements 3.1, 3.2, 3.3, 3.4
+ */
+class SlowTestsPreservationTest {
+
+    private static final int EXPECTED_TRIES = 100;
+
+    /** Returns all methods annotated with {@code @Property} in the given class. */
+    private List<Method> propertyMethods(Class<?> clazz) {
+        return Arrays.stream(clazz.getDeclaredMethods())
+                .filter(m -> m.isAnnotationPresent(Property.class))
+                .toList();
+    }
+
+    /** Asserts that every @Property method in the class has tries == expectedTries. */
+    private void assertAllTriesEquals(Class<?> clazz, int expectedTries, int expectedCount) {
+        List<Method> methods = propertyMethods(clazz);
+
+        assertEquals(expectedCount, methods.size(),
+                clazz.getSimpleName() + " must have exactly " + expectedCount + " @Property methods");
+
+        for (Method m : methods) {
+            int actual = m.getAnnotation(Property.class).tries();
+            assertEquals(expectedTries, actual,
+                    clazz.getSimpleName() + "." + m.getName()
+                            + " must have tries = " + expectedTries + " but was " + actual);
+        }
+    }
+
+    @Test
+    void mergeTreeBuilderPropertyTest_hasTriesOf100() throws ClassNotFoundException {
+        // MergeTreeBuilderPropertyTest: property21, property22, property23 (x2), property24 = 5 methods
+        Class<?> clazz = Class.forName("rawit.processors.merge.MergeTreeBuilderPropertyTest");
+        assertAllTriesEquals(clazz, EXPECTED_TRIES, 5);
+    }
+
+    @Test
+    void invokerClassSpecPropertyTest_hasTriesOf100() throws ClassNotFoundException {
+        // InvokerClassSpecPropertyTest: property2, property5, property6 (x2), property7 (x2), property8 (x2) = 8 methods
+        Class<?> clazz = Class.forName("rawit.processors.codegen.InvokerClassSpecPropertyTest");
+        assertAllTriesEquals(clazz, EXPECTED_TRIES, 8);
+    }
+
+    @Test
+    void stageInterfaceSpecPropertyTest_hasTriesOf100() throws ClassNotFoundException {
+        // StageInterfaceSpecPropertyTest: property9, property10, property11, property13,
+        // stageInterfaceNamesFollowConvention, property3, primitiveTypesAreNotBoxed = 7 methods
+        Class<?> clazz = Class.forName("rawit.processors.codegen.StageInterfaceSpecPropertyTest");
+        assertAllTriesEquals(clazz, EXPECTED_TRIES, 7);
+    }
+
+    @Test
+    void terminalInterfaceSpecPropertyTest_hasTriesOf100() throws ClassNotFoundException {
+        // TerminalInterfaceSpecPropertyTest: property12 (x2), property13 (x2), property14 (x2),
+        // invokeReturnTypeMatchesDescriptor, property4, property5 = 9 methods
+        Class<?> clazz = Class.forName("rawit.processors.codegen.TerminalInterfaceSpecPropertyTest");
+        assertAllTriesEquals(clazz, EXPECTED_TRIES, 9);
+    }
+}

--- a/src/test/java/rawit/processors/RawitAnnotationProcessorConstructorPropertyTest.java
+++ b/src/test/java/rawit/processors/RawitAnnotationProcessorConstructorPropertyTest.java
@@ -207,7 +207,7 @@ class RawitAnnotationProcessorConstructorPropertyTest {
      *
      * Validates: Requirements 16.1, 16.2
      */
-    @Property(tries = 10)
+    @Property(tries = 5)
     void property25_constructorEntryPointIsPublicStatic(
             @ForAll("paramCount") int n
     ) throws Exception {
@@ -251,7 +251,7 @@ class RawitAnnotationProcessorConstructorPropertyTest {
      *
      * Validates: Requirements 17.1
      */
-    @Property(tries = 10)
+    @Property(tries = 5)
     void property26_constructorCallerClassIsPublic(
             @ForAll("paramCount") int n
     ) throws Exception {
@@ -285,7 +285,7 @@ class RawitAnnotationProcessorConstructorPropertyTest {
      *
      * Validates: Requirements 19.2
      */
-    @Property(tries = 10)
+    @Property(tries = 5)
     void property27_constructStageInvokerHasConstructMethod(
             @ForAll("paramCount") int n
     ) throws Exception {

--- a/src/test/java/rawit/processors/RawitAnnotationProcessorPropertyTest.java
+++ b/src/test/java/rawit/processors/RawitAnnotationProcessorPropertyTest.java
@@ -217,7 +217,7 @@ class RawitAnnotationProcessorPropertyTest {
      *
      * Validates: Requirements 6.6, 8.1, 8.2, 12.4, 19.3, 19.4
      */
-    @Property(tries = 10)
+    @Property(tries = 5)
     void property1_roundTripEquivalenceWithInvoker(
             @ForAll("smallInt") int x,
             @ForAll("smallInt") int y
@@ -265,7 +265,7 @@ class RawitAnnotationProcessorPropertyTest {
      *
      * Validates: Requirements 7.1, 7.2
      */
-    @Property(tries = 10)
+    @Property(tries = 5)
     void property16_multipleAnnotationsProduceSeparateCallerClasses(
             @ForAll("distinctMethodNames") List<String> methodNames
     ) throws Exception {
@@ -333,7 +333,7 @@ class RawitAnnotationProcessorPropertyTest {
      *
      * Validates: Requirements 8.4
      */
-    @Property(tries = 10)
+    @Property(tries = 5)
     void property18_invokeIdempotency(
             @ForAll("smallInt") int x,
             @ForAll("smallInt") int y

--- a/src/test/java/rawit/processors/inject/BytecodeInjectorPropertyTest.java
+++ b/src/test/java/rawit/processors/inject/BytecodeInjectorPropertyTest.java
@@ -215,7 +215,7 @@ class BytecodeInjectorPropertyTest {
     // Feature: project-rawit-curry, Property 2: Parameterless overload is injected
     // -------------------------------------------------------------------------
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property2_parameterlessOverloadIsInjected(
             @ForAll("anyMethodName") String methodName,
             @ForAll("paramList") List<Parameter> params
@@ -253,7 +253,7 @@ class BytecodeInjectorPropertyTest {
     // Feature: project-rawit-curry, Property 3: Parameterless overload preserves access modifier
     // -------------------------------------------------------------------------
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property3_parameterlessOverloadPreservesAccessModifier(
             @ForAll("anyMethodName") String methodName,
             @ForAll("paramList") List<Parameter> params,
@@ -303,7 +303,7 @@ class BytecodeInjectorPropertyTest {
     // Feature: project-rawit-curry, Property 4: Parameterless overload returns the Entry_Stage type
     // -------------------------------------------------------------------------
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property4_parameterlessOverloadReturnsEntryStageType(
             @ForAll("anyMethodName") String methodName,
             @ForAll("paramList") List<Parameter> params
@@ -345,7 +345,7 @@ class BytecodeInjectorPropertyTest {
     // Feature: project-rawit-curry, Property 17: Generated .class files load without VerifyError
     // -------------------------------------------------------------------------
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property17_generatedClassFilesLoadWithoutVerifyError(
             @ForAll("anyMethodName") String methodName,
             @ForAll("paramList") List<Parameter> params
@@ -389,7 +389,7 @@ class BytecodeInjectorPropertyTest {
     // Feature: project-rawit-curry, Property 19: Injection idempotency — re-running the injector is a no-op
     // -------------------------------------------------------------------------
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property19_injectionIdempotency(
             @ForAll("anyMethodName") String methodName,
             @ForAll("paramList") List<Parameter> params

--- a/src/test/java/rawit/processors/validation/ElementValidatorPropertyTest.java
+++ b/src/test/java/rawit/processors/validation/ElementValidatorPropertyTest.java
@@ -136,7 +136,7 @@ class ElementValidatorPropertyTest {
     // Property 1: Valid element produces no errors
     // -------------------------------------------------------------------------
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property1_validInvokerMethod_producesNoErrors(
             @ForAll("validMethodNames") String methodName,
             @ForAll("paramTypeLists") List<String> paramTypes,
@@ -164,7 +164,7 @@ class ElementValidatorPropertyTest {
                 .formatted(methodName, visibility, paramTypes.size(), errorCount, diags));
     }
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property1_validInvokerConstructor_producesNoErrors(
             @ForAll("paramTypeLists") List<String> paramTypes,
             @ForAll("validVisibilities") String visibility) {
@@ -191,7 +191,7 @@ class ElementValidatorPropertyTest {
                 .formatted(visibility, paramTypes.size(), errorCount, diags));
     }
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property1_validConstructorAnnotation_producesNoErrors(
             @ForAll("paramTypeLists") List<String> paramTypes,
             @ForAll("validVisibilities") String visibility) {
@@ -222,7 +222,7 @@ class ElementValidatorPropertyTest {
     // Property 20: Exactly one error per violated validation rule
     // -------------------------------------------------------------------------
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property20_invokerZeroParams_exactlyOneError(
             @ForAll("validMethodNames") String methodName,
             @ForAll("validVisibilities") String visibility) {
@@ -258,7 +258,7 @@ class ElementValidatorPropertyTest {
                 .formatted(errorCount, diags));
     }
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property20_invokerPrivateMethod_exactlyOneError(
             @ForAll("validMethodNames") String methodName,
             @ForAll("paramTypeLists") List<String> paramTypes) {
@@ -285,7 +285,7 @@ class ElementValidatorPropertyTest {
                 .formatted(paramTypes.size(), errorCount, diags));
     }
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property20_invokerZeroParamsConstructor_exactlyOneError(
             @ForAll("validVisibilities") String visibility) {
         // Feature: curry-to-invoker-rename, Property 20: Exactly one error per violated validation rule
@@ -311,7 +311,7 @@ class ElementValidatorPropertyTest {
                 .formatted(visibility, errorCount, diags));
     }
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property20_invokerPrivateConstructor_exactlyOneError(
             @ForAll("paramTypeLists") List<String> paramTypes) {
         // Feature: curry-to-invoker-rename, Property 20: Exactly one error per violated validation rule
@@ -337,7 +337,7 @@ class ElementValidatorPropertyTest {
                 .formatted(paramTypes.size(), errorCount, diags));
     }
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property20_constructorAnnotationZeroParams_exactlyOneError(
             @ForAll("validVisibilities") String visibility) {
         // Feature: curry-to-invoker-rename, Property 20: Exactly one error per violated validation rule
@@ -363,7 +363,7 @@ class ElementValidatorPropertyTest {
                 .formatted(visibility, errorCount, diags));
     }
 
-    @Property(tries = 100)
+    @Property(tries = 5)
     void property20_constructorAnnotationPrivate_exactlyOneError(
             @ForAll("paramTypeLists") List<String> paramTypes) {
         // Feature: curry-to-invoker-rename, Property 20: Exactly one error per violated validation rule


### PR DESCRIPTION
Reduces \@Property(tries)\ on the four test classes that invoke \JavaCompiler\ on every try, cutting unnecessary compiler invocations without sacrificing correctness.

- \ElementValidatorPropertyTest\: 100 → 5 (9 methods)
- \BytecodeInjectorPropertyTest\: 100 → 5 (5 methods)
- \RawitAnnotationProcessorPropertyTest\: 10 → 5 (3 methods)
- \RawitAnnotationProcessorConstructorPropertyTest\: 10 → 5 (3 methods)

Pure in-memory property tests remain at 100 tries. Also adds \SlowTestsBugConditionExplorationTest\ and \SlowTestsPreservationTest\ to verify the fix and guard against regressions.

Closes #8