### PR TITLE
feat: support @Constructor on record type declarations

### DIFF
--- a/.kiro/specs/record-constructor-support/.config.kiro
+++ b/.kiro/specs/record-constructor-support/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "5852fd2a-d9df-47b0-b13e-8734eec04caa", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/record-constructor-support/design.md
+++ b/.kiro/specs/record-constructor-support/design.md
@@ -1,0 +1,280 @@
+# Design Document: Record Constructor Support
+
+## Overview
+
+This design extends the Rawit annotation processor to support `@Constructor` on Java record type declarations. Today, `@Constructor` targets only `ExecutableElement` (constructors inside classes). This feature adds a second code path: when `@Constructor` appears on a `TypeElement` with `ElementKind.RECORD`, the processor derives the canonical constructor's parameters from the record's components and builds the same `AnnotatedMethod` model that the rest of the pipeline (overload grouping, merge tree, code generation, bytecode injection) already consumes.
+
+The key insight is that the downstream pipeline is model-driven — once a correct `AnnotatedMethod` is constructed, everything from `MergeTreeBuilder` through `JavaPoetGenerator` and `BytecodeInjector` works unchanged. The changes are therefore concentrated in three areas:
+
+1. The `@Constructor` annotation's `@Target` metadata (add `TYPE`)
+2. `ElementValidator` — new validation branch for `TypeElement` with kind `RECORD`
+3. `RawitAnnotationProcessor.process()` — new branch to handle `TypeElement`, derive parameters from record components, and build `AnnotatedMethod`
+
+## Architecture
+
+The existing processing pipeline is:
+
+```mermaid
+flowchart LR
+    A["Collect annotated elements"] --> B["ElementValidator"]
+    B --> C["Build AnnotatedMethod"]
+    C --> D["Group into OverloadGroup"]
+    D --> E["MergeTreeBuilder"]
+    E --> F["JavaPoetGenerator"]
+    F --> G["BytecodeInjector"]
+```
+
+With this feature, the pipeline gains a fork at steps B and C:
+
+```mermaid
+flowchart TD
+    A["Collect annotated elements"] --> B{Element type?}
+    B -->|ExecutableElement| C1["Existing constructor/method validation"]
+    B -->|TypeElement RECORD| C2["New record-type validation"]
+    C1 --> D["Build AnnotatedMethod from ExecutableElement"]
+    C2 --> E["Build AnnotatedMethod from record components"]
+    D --> F["OverloadGroup → MergeTree → CodeGen → Injection"]
+    E --> F
+```
+
+Steps D through G (OverloadGroup, MergeTreeBuilder, JavaPoetGenerator, BytecodeInjector) are unchanged. The `AnnotatedMethod` record already carries all the fields needed (`isConstructor=true`, `isConstructorAnnotation=true`, `methodName="<init>"`, parameters derived from components).
+
+## Components and Interfaces
+
+### 1. `rawit.Constructor` annotation
+
+Current `@Target`: `ElementType.CONSTRUCTOR`
+
+New `@Target`: `{ElementType.CONSTRUCTOR, ElementType.TYPE}`
+
+No other changes to the annotation. `@Retention(RetentionPolicy.SOURCE)` stays the same.
+
+### 2. `ElementValidator`
+
+A new private method `validateConstructorOnType(Element, Messager)` handles `TypeElement` validation:
+
+```java
+private ValidationResult validateConstructorOnType(Element element, Messager messager) {
+    // 1. element must be a TypeElement with kind RECORD
+    // 2. record must have ≥ 1 record component
+    // 3. no existing zero-param static method named "constructor"
+}
+```
+
+The existing `validateConstructor(Element, Messager)` method is renamed to `validateConstructorOnExecutable` for clarity. The top-level `validate()` dispatch becomes:
+
+```java
+if (hasConstructor) {
+    if (element instanceof TypeElement te && te.getKind() == ElementKind.RECORD) {
+        return validateConstructorOnType(element, messager);
+    }
+    if (element.getKind() == ElementKind.CONSTRUCTOR) {
+        return validateConstructorOnExecutable(element, messager);
+    }
+    // Not a record type and not a constructor → error
+    messager.printMessage(ERROR, "@Constructor on a type is only supported for records", element);
+    return ValidationResult.invalid();
+}
+```
+
+Validation rules for record types:
+- Must be `ElementKind.RECORD` (not CLASS, INTERFACE, ENUM)
+- Must have ≥ 1 record component (reject zero-component records)
+- Must not already have a zero-param static method named `constructor`
+
+The conflict check for records scans `TypeElement.getEnclosedElements()` directly (the record type IS the enclosing element, unlike the constructor case where we look at `exec.getEnclosingElement()`).
+
+### 3. `RawitAnnotationProcessor`
+
+The `process()` method currently casts every annotated element to `ExecutableElement` and skips non-executable elements. The change:
+
+```java
+for (final Element element : roundEnv.getElementsAnnotatedWith(annotation)) {
+    final ValidationResult result = elementValidator.validate(element, messager);
+    if (result instanceof ValidationResult.Invalid) continue;
+
+    if (element instanceof TypeElement typeElement
+            && typeElement.getKind() == ElementKind.RECORD) {
+        // New record-type path
+        final AnnotatedMethod model = buildAnnotatedMethodFromRecord(typeElement);
+        if (model != null) validMethods.add(model);
+    } else if (element instanceof ExecutableElement exec) {
+        // Existing constructor/method path
+        final AnnotatedMethod model = buildAnnotatedMethod(exec);
+        if (model != null) validMethods.add(model);
+    }
+}
+```
+
+New private method `buildAnnotatedMethodFromRecord(TypeElement)`:
+
+```java
+private AnnotatedMethod buildAnnotatedMethodFromRecord(TypeElement recordElement) {
+    String enclosingClassName = toBinaryName(recordElement);
+    List<Parameter> parameters = new ArrayList<>();
+    for (RecordComponentElement comp : recordElement.getRecordComponents()) {
+        String name = comp.getSimpleName().toString();
+        String descriptor = toTypeDescriptor(comp.asType());
+        parameters.add(new Parameter(name, descriptor));
+    }
+    int accessFlags = resolveRecordAccessFlags(recordElement);
+    return new AnnotatedMethod(
+        enclosingClassName, "<init>", false, true, true,
+        parameters, "V", List.of(), accessFlags);
+}
+```
+
+Key details:
+- `getRecordComponents()` returns components in declaration order (JLS guarantee)
+- Type descriptors are derived from `comp.asType()` using the existing `toTypeDescriptor()` method
+- `checkedExceptions` is empty — canonical record constructors cannot declare checked exceptions
+- Access flags are derived from the record type's modifiers (public record → ACC_PUBLIC)
+
+### 4. Downstream pipeline (unchanged)
+
+- `OverloadGroup`: receives the `AnnotatedMethod` with `methodName="<init>"` and `isConstructorAnnotation=true` — groups correctly
+- `MergeTreeBuilder`: builds the merge tree from the single-member group — works as-is
+- `InvokerClassSpec`: detects `isConstructorAnnotation()` → generates `Constructor` class with `construct()` terminal — works as-is
+- `StageInterfaceSpec`: generates stage interfaces with `StageConstructor` suffix — works as-is
+- `TerminalInterfaceSpec`: generates `ConstructStageInvoker` with `construct()` — works as-is
+- `BytecodeInjector`: detects `isConstructorAnnotation()` group → injects `public static constructor()` — works as-is
+
+## Data Models
+
+No new data models are introduced. The existing `AnnotatedMethod` record already has all required fields:
+
+| Field | Value for record-type annotation |
+|---|---|
+| `enclosingClassName` | Binary name of the record, e.g. `"com/example/Point"` |
+| `methodName` | `"<init>"` |
+| `isStatic` | `false` |
+| `isConstructor` | `true` |
+| `isConstructorAnnotation` | `true` |
+| `parameters` | Derived from record components in declaration order |
+| `returnTypeDescriptor` | `"V"` |
+| `checkedExceptions` | `List.of()` (canonical constructors can't throw checked exceptions) |
+| `accessFlags` | Derived from record type modifiers (typically `0x0001` for public) |
+
+The `Parameter` record is reused as-is — each record component maps to a `Parameter(name, typeDescriptor)`.
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Record AnnotatedMethod construction correctness
+
+*For any* record type with N ≥ 1 components, building an `AnnotatedMethod` from that record SHALL produce a model where `enclosingClassName` equals the slash-separated binary name of the record, `methodName` equals `"<init>"`, `isConstructor` is `true`, `isConstructorAnnotation` is `true`, and `parameters` is a list of N `Parameter` entries whose names and type descriptors match the record components in declaration order.
+
+**Validates: Requirements 3.2, 3.3, 3.4**
+
+### Property 2: Validation accepts valid records
+
+*For any* `TypeElement` with kind `RECORD` that has at least one record component and no existing zero-parameter static method named `constructor`, the `ElementValidator` SHALL return `ValidationResult.Valid`.
+
+**Validates: Requirements 2.1**
+
+### Property 3: Validation rejects non-record types
+
+*For any* `TypeElement` with kind other than `RECORD` (CLASS, INTERFACE, ENUM) annotated with `@Constructor`, the `ElementValidator` SHALL return `ValidationResult.Invalid` and emit an error diagnostic.
+
+**Validates: Requirements 2.3**
+
+### Property 4: Validation detects constructor() conflict on records
+
+*For any* record type that already declares a zero-parameter static method named `constructor`, the `ElementValidator` SHALL return `ValidationResult.Invalid` and emit an error diagnostic mentioning the conflict.
+
+**Validates: Requirements 2.4**
+
+### Property 5: Type descriptor correctness for record components
+
+*For any* record component type — whether primitive (`int`, `boolean`, etc.), reference (`String`, `List<T>`, etc.), or array (`int[]`, `String[][]`, etc.) — the `toTypeDescriptor()` method SHALL produce the correct JVM type descriptor (`I` for int, `Ljava/lang/String;` for String, `[I` for int[], etc.), with generic types erased to their raw bounds.
+
+**Validates: Requirements 7.1, 7.2, 7.3**
+
+### Property 6: Code generation produces correct staged API for records
+
+*For any* record-derived `AnnotatedMethod` with N parameters, the `JavaPoetGenerator` pipeline SHALL produce a `Constructor` caller class in the same package as the record, containing N stage interfaces with setter methods matching the parameter names in order, and a `ConstructStageInvoker` terminal interface with a `construct()` method returning the record type.
+
+**Validates: Requirements 5.1, 5.2, 5.3**
+
+### Property 7: Bytecode injection produces correct entry point for records
+
+*For any* record whose `.class` file does not already contain a zero-parameter method named `constructor`, the `BytecodeInjector` SHALL inject a `public static constructor()` method whose bytecode instantiates and returns the generated `Constructor` caller class.
+
+**Validates: Requirements 6.1, 6.2**
+
+### Property 8: Injection idempotency
+
+*For any* record whose `.class` file already contains a zero-parameter method named `constructor`, the `BytecodeInjector` SHALL skip injection for that overload group, leaving the existing method unchanged.
+
+**Validates: Requirements 6.3**
+
+### Property 9: Backward compatibility for regular class constructors
+
+*For any* regular (non-record) class constructor annotated with `@Constructor`, the `ElementValidator` SHALL apply the same validation rules as before this feature, and the `RawitAnnotationProcessor` SHALL build the `AnnotatedMethod` using the existing `ExecutableElement`-based code path, producing identical output to the pre-feature behavior.
+
+**Validates: Requirements 1.2, 8.1, 8.2**
+
+### Property 10: Independent processing of records and regular classes
+
+*For any* compilation round containing both a `@Constructor`-annotated record type and a `@Constructor`-annotated regular class constructor, the processor SHALL produce correct `AnnotatedMethod` models for both, and neither SHALL interfere with the other's overload grouping, code generation, or bytecode injection.
+
+**Validates: Requirements 8.3**
+
+### Property 11: Pipeline integration for record-derived AnnotatedMethod
+
+*For any* `AnnotatedMethod` built from a record type, the model SHALL successfully pass through `OverloadGroup` construction, `MergeTreeBuilder.build()`, and `InvokerClassSpec.build()` without errors, producing a valid merge tree and generated source code.
+
+**Validates: Requirements 4.3**
+
+## Error Handling
+
+| Scenario | Diagnostic | Severity |
+|---|---|---|
+| `@Constructor` on a non-record type (class, interface, enum) | `@Constructor on a type is only supported for records` | ERROR |
+| `@Constructor` on a record with zero components | `staged construction requires at least one record component` | ERROR |
+| `@Constructor` on a record that already has a `constructor()` method | `a parameterless overload named 'constructor' already exists` | ERROR |
+| `.class` file not found during injection phase | Debug NOTE (silent skip) | NOTE |
+| Bytecode verification failure after injection | `BytecodeInjector: bytecode verification failed` — original `.class` preserved | ERROR |
+| Generated source file already exists (incremental build) | Logged as NOTE, skipped silently | NOTE |
+
+All error diagnostics are emitted via `Messager.printMessage(Diagnostic.Kind.ERROR, ...)` with the offending element attached, so IDEs can highlight the exact annotation location.
+
+The validator checks ALL applicable rules without short-circuiting (consistent with existing behavior), so that every error is surfaced in a single compilation pass.
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+This feature uses both unit tests and property-based tests:
+
+- **Unit tests**: Verify specific examples (e.g., `@Constructor` on `record Point(int x, int y)` produces the expected `AnnotatedMethod`), edge cases (zero-component records, non-record types), and integration scenarios (end-to-end compilation with both records and regular classes).
+- **Property-based tests**: Verify universal properties across randomly generated inputs (e.g., for any record with N components, the derived `AnnotatedMethod` has N parameters in order).
+
+### Property-Based Testing Configuration
+
+- **Library**: jqwik (already used in the project)
+- **Minimum iterations**: 100 per property test
+- **Tag format**: `Feature: record-constructor-support, Property {number}: {property_text}`
+- Each correctness property above is implemented by a single `@Property`-annotated test method
+- Generators produce random record component lists (varying names, types including primitives, references, arrays, and generics)
+
+### Test Organization
+
+- `ElementValidatorTest` / `ElementValidatorPropertyTest` — extended with record-type validation cases
+- `RawitAnnotationProcessorPropertyTest` — extended with record-type AnnotatedMethod construction properties
+- `RawitAnnotationProcessorIntegrationTest` — extended with end-to-end record compilation tests
+- `BytecodeInjectorTest` / `BytecodeInjectorPropertyTest` — extended with record injection cases
+- `InvokerClassSpecTest` / `InvokerClassSpecPropertyTest` — extended with record-derived merge tree code generation
+
+### Key Test Scenarios
+
+1. Valid record with primitive components → successful processing
+2. Valid record with mixed types (primitives, references, arrays, generics) → correct type descriptors
+3. Zero-component record → validation error
+4. Non-record type with `@Constructor` → validation error
+5. Record with existing `constructor()` method → conflict error
+6. Regular class constructor with `@Constructor` → unchanged behavior (regression)
+7. Same compilation round with both record and regular class → independent processing
+8. Idempotent injection — running injection twice produces same result

--- a/.kiro/specs/record-constructor-support/requirements.md
+++ b/.kiro/specs/record-constructor-support/requirements.md
@@ -1,0 +1,289 @@
+# Requirements Document
+
+## Introduction
+
+This feature extends the Rawit annotation processor to support placing `@Constructor` directly on a Java record type declaration. Instead of annotating a constructor inside the record, the developer annotates the record type itself. The processor derives the canonical constructor parameters from the record's component declarations and generates the same staged construction API that `@Constructor`-on-constructor provides for regular classes. The existing behavior of `@Constructor` on explicit constructors in regular classes is preserved (backward compatible).
+
+## Glossary
+
+- **Processor**: The `RawitAnnotationProcessor` that processes `@Invoker` and `@Constructor` annotations
+- **Validator**: The `ElementValidator` that checks annotated elements against structural rules
+- **Record_Type**: A `TypeElement` whose `ElementKind` is `RECORD`
+- **Record_Component**: A component declared in the record header (e.g., `int x` in `record Point(int x, int y)`)
+- **Canonical_Constructor**: The compiler-generated constructor of a record whose parameter list matches the record components exactly
+- **Injector**: The `BytecodeInjector` that injects parameterless overload methods into `.class` files using ASM
+- **Caller_Class**: The generated top-level class (e.g., `Constructor`) containing stage interfaces and the terminal `construct()` method
+- **Constructor_Annotation**: The `@Constructor` annotation defined in `rawit.Constructor`
+
+## Requirements
+
+### Requirement 1: Expand @Constructor Target to Include TYPE
+
+**User Story:** As a developer, I want to place `@Constructor` on a record type declaration, so that I do not need to write an explicit constructor inside the record.
+
+#### Acceptance Criteria
+
+1. THE Constructor_Annotation SHALL declare `@Target({ElementType.CONSTRUCTOR, ElementType.TYPE})` to allow placement on both constructors and type declarations
+2. WHEN `@Constructor` is placed on a regular class constructor, THE Processor SHALL continue to process the element using the existing constructor-annotation code path (backward compatibility)
+
+#### Examples
+
+Primary syntax — annotation on the record type:
+
+```java
+@Constructor
+public record Point(int x, int y) { }
+
+// Usage:
+Point p = Point.constructor().x(1).y(2).construct();
+```
+
+Backward-compatible syntax — annotation on a regular class constructor:
+
+```java
+public class Pair {
+    private final int a;
+    private final int b;
+
+    @Constructor
+    public Pair(int a, int b) {
+        this.a = a;
+        this.b = b;
+    }
+}
+
+// Usage:
+Pair p = Pair.constructor().a(1).b(2).construct();
+```
+
+### Requirement 2: Validate @Constructor on Record Types
+
+**User Story:** As a developer, I want clear compile-time errors when I misuse `@Constructor` on a type, so that I understand what went wrong.
+
+#### Acceptance Criteria
+
+1. WHEN `@Constructor` is placed on a Record_Type with at least one Record_Component, THE Validator SHALL accept the element as valid
+2. WHEN `@Constructor` is placed on a Record_Type with zero Record_Components, THE Validator SHALL emit an error stating that staged construction requires at least one record component
+3. WHEN `@Constructor` is placed on a type that is not a Record_Type (class, interface, or enum), THE Validator SHALL emit an error stating that `@Constructor` on a type is only supported for records
+4. WHEN `@Constructor` is placed on a Record_Type that already declares a zero-parameter static method named `constructor`, THE Validator SHALL emit an error stating that a parameterless overload named 'constructor' already exists
+
+#### Examples
+
+Valid — record with components:
+
+```java
+@Constructor
+public record Point(int x, int y) { }
+```
+
+Invalid — record with zero components:
+
+```java
+@Constructor
+public record Empty() { }
+// Error: staged construction requires at least one record component
+```
+
+Invalid — annotation on a regular class (not a record):
+
+```java
+@Constructor
+public class NotARecord {
+    private final int x;
+    public NotARecord(int x) { this.x = x; }
+}
+// Error: @Constructor on a type is only supported for records
+```
+
+Invalid — annotation on an interface:
+
+```java
+@Constructor
+public interface NotARecord { }
+// Error: @Constructor on a type is only supported for records
+```
+
+Invalid — conflicting zero-param method:
+
+```java
+@Constructor
+public record Conflict(int x) {
+    public static Conflict constructor() {
+        return new Conflict(0);
+    }
+}
+// Error: a parameterless overload named 'constructor' already exists
+```
+
+
+### Requirement 3: Derive Constructor Parameters from Record Components
+
+**User Story:** As a developer, I want the processor to automatically derive constructor parameters from the record header, so that I do not need to write an explicit constructor.
+
+#### Acceptance Criteria
+
+1. WHEN the Processor encounters a `@Constructor`-annotated Record_Type, THE Processor SHALL locate the Canonical_Constructor of the record
+2. WHEN the Processor locates the Canonical_Constructor, THE Processor SHALL extract parameter names and types from the record's Record_Components in declaration order
+3. WHEN the Processor builds an `AnnotatedMethod` for a `@Constructor`-annotated Record_Type, THE Processor SHALL set `isConstructor` to `true`, `isConstructorAnnotation` to `true`, and `methodName` to `<init>`
+4. WHEN the Processor builds an `AnnotatedMethod` for a `@Constructor`-annotated Record_Type, THE Processor SHALL set `enclosingClassName` to the binary name of the Record_Type using the same slash-separated format as for regular classes
+
+#### Examples
+
+Given this annotated record:
+
+```java
+package com.example;
+
+@Constructor
+public record Point(int x, int y) { }
+```
+
+The Processor derives parameters from the record components `(int x, int y)` and builds an `AnnotatedMethod` equivalent to:
+
+```java
+new AnnotatedMethod(
+    "com/example/Point",  // enclosingClassName
+    "<init>",             // methodName
+    false,                // isStatic
+    true,                 // isConstructor
+    true,                 // isConstructorAnnotation
+    List.of(new Parameter("x", "I"), new Parameter("y", "I")),
+    "V",                  // returnTypeDescriptor
+    List.of(),            // checkedExceptions
+    0x0001                // ACC_PUBLIC
+);
+```
+
+### Requirement 4: Handle TypeElement in Processor Pipeline
+
+**User Story:** As a developer, I want the processor to handle `@Constructor` on a `TypeElement` (not just `ExecutableElement`), so that record type annotations are processed correctly.
+
+#### Acceptance Criteria
+
+1. WHEN the Processor encounters an element annotated with `@Constructor` that is a `TypeElement` with kind `RECORD`, THE Processor SHALL process the element through the record-type code path instead of the constructor code path
+2. WHEN the Processor encounters an element annotated with `@Constructor` that is an `ExecutableElement`, THE Processor SHALL continue to process the element through the existing constructor code path
+3. WHEN the Processor processes a `@Constructor`-annotated Record_Type, THE Processor SHALL produce an `AnnotatedMethod` model that integrates with the existing overload grouping, merge tree building, and code generation pipeline
+
+### Requirement 5: Generate Staged Construction API for Records
+
+**User Story:** As a developer, I want the generated staged API for records to follow the same pattern as regular classes, so that the usage is consistent.
+
+#### Acceptance Criteria
+
+1. WHEN a Record_Type is annotated with `@Constructor`, THE Processor SHALL generate a `Constructor` Caller_Class in the same package as the record
+2. WHEN a Record_Type is annotated with `@Constructor`, THE Processor SHALL generate stage interfaces with setter methods matching each Record_Component name in declaration order
+3. WHEN a Record_Type is annotated with `@Constructor`, THE Processor SHALL generate a terminal interface with a `construct()` method that returns the Record_Type
+
+#### Examples
+
+Given this annotated record:
+
+```java
+package com.example;
+
+@Constructor
+public record Point(int x, int y) { }
+```
+
+The Processor generates a Caller_Class with stage interfaces, and the resulting staged API usage is:
+
+```java
+Point p = Point.constructor()  // returns stage 1 interface
+    .x(10)                     // returns stage 2 interface
+    .y(20)                     // returns terminal interface
+    .construct();              // calls new Point(10, 20)
+```
+
+The generated Caller_Class structure (in `com.example.Constructor`):
+
+```java
+package com.example;
+
+public final class Constructor {
+    public interface Stage1_x { Stage2_y x(int x); }
+    public interface Stage2_y { Terminal y(int y); }
+    public interface Terminal  { Point construct(); }
+
+    // Implementation wiring omitted for brevity
+}
+```
+
+### Requirement 6: Inject Static Entry Point into Record Class Files
+
+**User Story:** As a developer, I want a `public static constructor()` method injected into my record's `.class` file, so that I can use the staged API seamlessly.
+
+#### Acceptance Criteria
+
+1. WHEN the Injector processes a Record_Type with a `@Constructor` annotation, THE Injector SHALL inject a `public static constructor()` method into the record's `.class` file
+2. WHEN the Injector injects a `constructor()` method into a record's `.class` file, THE Injector SHALL generate bytecode that instantiates and returns the first stage interface of the Caller_Class
+3. IF the record's `.class` file already contains a zero-parameter method named `constructor`, THEN THE Injector SHALL skip injection for that overload group
+
+#### Examples
+
+After injection, the record's `.class` file behaves as if the following method were declared in source:
+
+```java
+@Constructor
+public record Point(int x, int y) {
+    // Injected by BytecodeInjector — not present in source
+    public static Constructor.Stage1_x constructor() {
+        return new Constructor(/* wiring */);
+    }
+}
+```
+
+This enables the seamless call chain:
+
+```java
+Point p = Point.constructor().x(1).y(2).construct();
+```
+
+### Requirement 7: Support Records with Various Component Types
+
+**User Story:** As a developer, I want `@Constructor` on records to work with all valid record component types, so that the feature is not limited to primitive types.
+
+#### Acceptance Criteria
+
+1. WHEN a `@Constructor`-annotated Record_Type has components with primitive types, THE Processor SHALL generate correct JVM type descriptors for each component
+2. WHEN a `@Constructor`-annotated Record_Type has components with reference types (including generics), THE Processor SHALL generate correct JVM type descriptors using erased types
+3. WHEN a `@Constructor`-annotated Record_Type has components with array types, THE Processor SHALL generate correct JVM array type descriptors
+
+#### Examples
+
+Record with mixed component types:
+
+```java
+@Constructor
+public record Config(String name, int port, boolean secure, String[] aliases) { }
+
+// Usage:
+Config c = Config.constructor()
+    .name("server")
+    .port(8080)
+    .secure(true)
+    .aliases(new String[]{"s1", "s2"})
+    .construct();
+```
+
+Record with generic component types (erased to Object):
+
+```java
+@Constructor
+public record Wrapper<T>(T value, String label) { }
+
+// Usage:
+Wrapper<Integer> w = Wrapper.constructor()
+    .value(42)
+    .label("answer")
+    .construct();
+```
+
+### Requirement 8: Preserve Backward Compatibility
+
+**User Story:** As a developer, I want existing `@Constructor` usage on regular class constructors to continue working unchanged, so that upgrading does not break my code.
+
+#### Acceptance Criteria
+
+1. WHEN `@Constructor` is placed on a constructor of a regular class (not a record), THE Validator SHALL apply the existing constructor validation rules without change
+2. WHEN `@Constructor` is placed on a constructor of a regular class, THE Processor SHALL build the `AnnotatedMethod` model using the existing `ExecutableElement`-based code path
+3. WHEN both a `@Constructor`-annotated Record_Type and a `@Constructor`-annotated regular class constructor exist in the same compilation round, THE Processor SHALL process both independently without interference

--- a/.kiro/specs/record-constructor-support/tasks.md
+++ b/.kiro/specs/record-constructor-support/tasks.md
@@ -1,0 +1,164 @@
+# Implementation Plan: Record Constructor Support
+
+## Overview
+
+Extend the Rawit annotation processor to support `@Constructor` on Java record type declarations. Changes are concentrated in three areas: the `@Constructor` annotation target, `ElementValidator` record-type validation, and `RawitAnnotationProcessor` record-type dispatch and `AnnotatedMethod` construction. The downstream pipeline (OverloadGroup, MergeTreeBuilder, JavaPoetGenerator, BytecodeInjector) is unchanged.
+
+## Tasks
+
+- [x] 1. Expand @Constructor annotation target to include TYPE
+  - [x] 1.1 Modify `@Target` in `src/main/java/rawit/Constructor.java`
+    - Change `@Target(ElementType.CONSTRUCTOR)` to `@Target({ElementType.CONSTRUCTOR, ElementType.TYPE})`
+    - No other changes to the annotation (retention stays SOURCE)
+    - _Requirements: 1.1_
+
+- [x] 2. Add record-type validation to ElementValidator
+  - [x] 2.1 Refactor `validateConstructor` dispatch in `src/main/java/rawit/processors/validation/ElementValidator.java`
+    - Rename existing `validateConstructor` to `validateConstructorOnExecutable`
+    - Add new top-level dispatch: if element is a `TypeElement` with kind `RECORD`, call `validateConstructorOnType`; if element is a `CONSTRUCTOR`, call `validateConstructorOnExecutable`; otherwise emit error "@Constructor on a type is only supported for records" and return invalid
+    - _Requirements: 2.1, 2.3, 4.1, 4.2_
+
+  - [x] 2.2 Implement `validateConstructorOnType` method
+    - Validate that the `TypeElement` has kind `RECORD` (reject CLASS, INTERFACE, ENUM with error "@Constructor on a type is only supported for records")
+    - Validate that the record has ≥ 1 record component (reject zero-component records with error "staged construction requires at least one record component")
+    - Scan `TypeElement.getEnclosedElements()` for an existing zero-parameter static method named `constructor` (reject with error "a parameterless overload named 'constructor' already exists")
+    - Check all rules without short-circuiting (consistent with existing validator behavior)
+    - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+  - [x] 2.3 Add unit tests for record-type validation in `src/test/java/rawit/processors/validation/ElementValidatorTest.java`
+    - Test: `@Constructor` on a valid record with components → no errors
+    - Test: `@Constructor` on a record with zero components → error about requiring at least one component
+    - Test: `@Constructor` on a regular class (not a record) → error about records only
+    - Test: `@Constructor` on an interface → error about records only
+    - Test: `@Constructor` on a record with existing `constructor()` method → conflict error
+    - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+  - [x] 2.4 Write property test: Validation accepts valid records
+    - **Property 2: Validation accepts valid records**
+    - For any `TypeElement` with kind `RECORD` that has at least one record component and no existing zero-parameter static method named `constructor`, the `ElementValidator` SHALL return `ValidationResult.Valid`
+    - Add to `src/test/java/rawit/processors/validation/ElementValidatorPropertyTest.java`
+    - **Validates: Requirements 2.1**
+
+  - [x] 2.5 Write property test: Validation rejects non-record types
+    - **Property 3: Validation rejects non-record types**
+    - For any `TypeElement` with kind other than `RECORD` (CLASS, INTERFACE, ENUM) annotated with `@Constructor`, the `ElementValidator` SHALL return `ValidationResult.Invalid` and emit an error diagnostic
+    - Add to `src/test/java/rawit/processors/validation/ElementValidatorPropertyTest.java`
+    - **Validates: Requirements 2.3**
+
+  - [x] 2.6 Write property test: Validation detects constructor() conflict on records
+    - **Property 4: Validation detects constructor() conflict on records**
+    - For any record type that already declares a zero-parameter static method named `constructor`, the `ElementValidator` SHALL return `ValidationResult.Invalid` and emit an error diagnostic mentioning the conflict
+    - Add to `src/test/java/rawit/processors/validation/ElementValidatorPropertyTest.java`
+    - **Validates: Requirements 2.4**
+
+- [x] 3. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 4. Add record-type dispatch and AnnotatedMethod construction to RawitAnnotationProcessor
+  - [x] 4.1 Add TypeElement dispatch fork in `process()` method of `src/main/java/rawit/processors/RawitAnnotationProcessor.java`
+    - After validation, check if element is `TypeElement` with kind `RECORD` → call new `buildAnnotatedMethodFromRecord(TypeElement)`
+    - Otherwise, keep existing `ExecutableElement` path via `buildAnnotatedMethod(ExecutableElement)`
+    - Remove the `if (!(element instanceof ExecutableElement exec)) continue;` guard and replace with the two-branch dispatch
+    - _Requirements: 4.1, 4.2, 4.3_
+
+  - [x] 4.2 Implement `buildAnnotatedMethodFromRecord(TypeElement)` method
+    - Use `toBinaryName(recordElement)` for `enclosingClassName`
+    - Iterate `recordElement.getRecordComponents()` in declaration order to build `List<Parameter>` using existing `toTypeDescriptor()` for each component's type
+    - Set `methodName="<init>"`, `isStatic=false`, `isConstructor=true`, `isConstructorAnnotation=true`
+    - Set `returnTypeDescriptor="V"`, `checkedExceptions=List.of()`
+    - Derive `accessFlags` from the record type's modifiers (public → ACC_PUBLIC, protected → ACC_PROTECTED, etc.)
+    - Add a private `resolveRecordAccessFlags(TypeElement)` helper method
+    - _Requirements: 3.1, 3.2, 3.3, 3.4_
+
+  - [x] 4.3 Write property test: Record AnnotatedMethod construction correctness
+    - **Property 1: Record AnnotatedMethod construction correctness**
+    - For any record type with N ≥ 1 components, building an `AnnotatedMethod` from that record SHALL produce a model where `enclosingClassName` equals the slash-separated binary name of the record, `methodName` equals `"<init>"`, `isConstructor` is `true`, `isConstructorAnnotation` is `true`, and `parameters` is a list of N `Parameter` entries whose names and type descriptors match the record components in declaration order
+    - Add to `src/test/java/rawit/processors/RawitAnnotationProcessorConstructorPropertyTest.java`
+    - **Validates: Requirements 3.2, 3.3, 3.4**
+
+  - [x] 4.4 Write property test: Type descriptor correctness for record components
+    - **Property 5: Type descriptor correctness for record components**
+    - For any record component type — whether primitive, reference, or array — the `toTypeDescriptor()` method SHALL produce the correct JVM type descriptor
+    - Add to `src/test/java/rawit/processors/RawitAnnotationProcessorConstructorPropertyTest.java`
+    - **Validates: Requirements 7.1, 7.2, 7.3**
+
+- [x] 5. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [-] 6. Add integration tests for record-type end-to-end processing
+  - [x] 6.1 Add integration test: `@Constructor` on a record produces working staged API
+    - Add test to `src/test/java/rawit/processors/RawitAnnotationProcessorIntegrationTest.java`
+    - Compile `@Constructor public record Point(int x, int y) {}` through the three-pass pipeline
+    - Verify `Point.constructor().x(1).y(2).construct()` returns a `Point` with `x=1, y=2`
+    - _Requirements: 5.1, 5.2, 5.3, 6.1, 6.2_
+
+  - [x] 6.2 Add integration test: `@Constructor` on a record with mixed types
+    - Add test to `src/test/java/rawit/processors/RawitAnnotationProcessorIntegrationTest.java`
+    - Compile `@Constructor public record Config(String name, int port, boolean secure) {}`
+    - Verify the staged API works with String, int, and boolean component types
+    - _Requirements: 7.1, 7.2_
+
+  - [x] 6.3 Add integration test: both record and regular class in same compilation round
+    - Add test to `src/test/java/rawit/processors/RawitAnnotationProcessorIntegrationTest.java`
+    - Compile a `@Constructor`-annotated record and a `@Constructor`-annotated regular class constructor in the same compilation unit
+    - Verify both produce independent working staged APIs
+    - _Requirements: 8.1, 8.2, 8.3_
+
+  - [x] 6.4 Write property test: Code generation produces correct staged API for records
+    - **Property 6: Code generation produces correct staged API for records**
+    - For any record-derived `AnnotatedMethod` with N parameters, the `JavaPoetGenerator` pipeline SHALL produce a `Constructor` caller class containing N stage interfaces with setter methods matching the parameter names in order, and a `ConstructStageInvoker` terminal interface with a `construct()` method returning the record type
+    - Add to `src/test/java/rawit/processors/RawitAnnotationProcessorConstructorPropertyTest.java`
+    - **Validates: Requirements 5.1, 5.2, 5.3**
+
+  - [x] 6.5 Write property test: Pipeline integration for record-derived AnnotatedMethod
+    - **Property 11: Pipeline integration for record-derived AnnotatedMethod**
+    - For any `AnnotatedMethod` built from a record type, the model SHALL successfully pass through `OverloadGroup` construction, `MergeTreeBuilder.build()`, and `InvokerClassSpec.build()` without errors
+    - Add to `src/test/java/rawit/processors/RawitAnnotationProcessorConstructorPropertyTest.java`
+    - **Validates: Requirements 4.3**
+
+  - [x] 6.6 Write property test: Backward compatibility for regular class constructors
+    - **Property 9: Backward compatibility for regular class constructors**
+    - For any regular (non-record) class constructor annotated with `@Constructor`, the `ElementValidator` SHALL apply the same validation rules as before this feature, and the `RawitAnnotationProcessor` SHALL build the `AnnotatedMethod` using the existing `ExecutableElement`-based code path, producing identical output to the pre-feature behavior
+    - Add to `src/test/java/rawit/processors/RawitAnnotationProcessorConstructorPropertyTest.java`
+    - **Validates: Requirements 1.2, 8.1, 8.2**
+
+  - [x] 6.7 Write property test: Independent processing of records and regular classes
+    - **Property 10: Independent processing of records and regular classes**
+    - For any compilation round containing both a `@Constructor`-annotated record type and a `@Constructor`-annotated regular class constructor, the processor SHALL produce correct `AnnotatedMethod` models for both, and neither SHALL interfere with the other's overload grouping, code generation, or bytecode injection
+    - Add to `src/test/java/rawit/processors/RawitAnnotationProcessorConstructorPropertyTest.java`
+    - **Validates: Requirements 8.3**
+
+- [x] 7. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [-] 8. Add bytecode injection tests for records
+  - [x] 8.1 Write property test: Bytecode injection produces correct entry point for records
+    - **Property 7: Bytecode injection produces correct entry point for records**
+    - For any record whose `.class` file does not already contain a zero-parameter method named `constructor`, the `BytecodeInjector` SHALL inject a `public static constructor()` method whose bytecode instantiates and returns the generated `Constructor` caller class
+    - Add to `src/test/java/rawit/processors/inject/BytecodeInjectorPropertyTest.java`
+    - **Validates: Requirements 6.1, 6.2**
+
+  - [x] 8.2 Write property test: Injection idempotency
+    - **Property 8: Injection idempotency**
+    - For any record whose `.class` file already contains a zero-parameter method named `constructor`, the `BytecodeInjector` SHALL skip injection for that overload group, leaving the existing method unchanged
+    - Add to `src/test/java/rawit/processors/inject/BytecodeInjectorPropertyTest.java`
+    - **Validates: Requirements 6.3**
+
+- [x] 9. Update sample projects
+  - [x] 9.1 Add record example to sample projects
+    - Add a `@Constructor`-annotated record to `samples/gradle-sample/src/main/java/com/example/rawit/Point.java` (or update existing Point if it's a class)
+    - Add corresponding test in `samples/gradle-sample/src/test/java/com/example/rawit/RawitSampleTest.java`
+    - Mirror changes in `samples/maven-sample/`
+    - _Requirements: 5.1, 5.2, 5.3_
+
+- [x] 10. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- The downstream pipeline (OverloadGroup, MergeTreeBuilder, JavaPoetGenerator, BytecodeInjector) requires no code changes — only new tests to verify record-derived models flow through correctly

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ foo.bar().x(10).y(20).invoke();
 ## ✨ Features
 
 - **`@Invoker`** — turns any non-private method (instance or static) into a staged call chain ending with `.invoke()`
-- **`@Constructor`** — injects a `public static constructor()` entry point for staged object construction ending with `.construct()`
-- Works on **instance methods** and **static methods** (`@Invoker`), and **constructors** (`@Constructor`)
+- **`@Constructor`** — injects a `public static constructor()` entry point for staged object construction ending with `.construct()`. Works on explicit constructors and directly on **record types**
+- Works on **instance methods** and **static methods** (`@Invoker`), **constructors**, and **record type declarations** (`@Constructor`)
 - Supports **overload groups** — multiple overloads with the same name share a single entry point and branch only where their signatures diverge
 - **Zero runtime dependency** — the processor runs at compile time only
 - Operates like **Lombok** — generates inner classes and interfaces via JavaPoet, and injects the parameterless entry-point overload directly into the original `.class` file using ASM
@@ -182,6 +182,10 @@ public class Point {
         this.y = y;
     }
 }
+
+// Records — just annotate the type, no explicit constructor needed
+@Constructor
+public record Coord(int x, int y) {}
 ```
 
 ### 3. Use the generated API
@@ -203,6 +207,12 @@ Point p = Point.constructor()
                .x(1)
                .y(2)
                .construct(); // == new Point(1, 2)
+
+// Record constructor — same API, no boilerplate
+Coord c = Coord.constructor()
+               .x(5)
+               .y(10)
+               .construct(); // == new Coord(5, 10)
 ```
 
 ---
@@ -233,7 +243,9 @@ mailer.sendEmail()
 
 ### `@Constructor`
 
-Place on any **non-private** constructor with **at least one parameter**.
+Place on any **non-private** constructor with **at least one parameter**, or directly on a **record type declaration**.
+
+#### On a constructor
 
 ```java
 @Constructor
@@ -251,6 +263,25 @@ User user = User.constructor()
                 .name("Alice")
                 .construct();
 ```
+
+#### On a record type
+
+```java
+@Constructor
+public record Config(String name, int port, boolean secure) {}
+```
+
+The processor derives parameters from the record's components automatically — no explicit constructor needed. The generated API is identical:
+
+```java
+Config cfg = Config.constructor()
+                   .name("server")
+                   .port(8080)
+                   .secure(true)
+                   .construct();
+```
+
+Records with zero components are rejected at compile time (`staged construction requires at least one record component`). Placing `@Constructor` on a non-record type (class, interface, enum) is also a compile-time error.
 
 ---
 
@@ -282,6 +313,9 @@ Rawit catches mistakes early. You'll get a clear `javac` error for:
 | `@Invoker` on a `private` method | `@Invoker requires at least package-private visibility` |
 | `@Constructor` on a non-constructor element | `@Constructor may only target constructors` |
 | `@Constructor` on a zero-parameter constructor | `staged construction requires at least one parameter` |
+| `@Constructor` on a non-record type (class, interface, enum) | `@Constructor on a type is only supported for records` |
+| `@Constructor` on a record with zero components | `staged construction requires at least one record component` |
+| `@Constructor` on a record with existing `constructor()` method | `a parameterless overload named 'constructor' already exists` |
 | A `bar()` overload already exists | `a parameterless overload named 'bar' already exists` |
 | Same parameter name with conflicting types across overloads | conflict error with details |
 

--- a/samples/gradle-sample/src/main/java/com/example/rawit/Coord.java
+++ b/samples/gradle-sample/src/main/java/com/example/rawit/Coord.java
@@ -1,0 +1,6 @@
+package com.example.rawit;
+
+import rawit.Constructor;
+
+@Constructor
+public record Coord(int x, int y) {}

--- a/samples/gradle-sample/src/test/java/com/example/rawit/RawitSampleTest.java
+++ b/samples/gradle-sample/src/test/java/com/example/rawit/RawitSampleTest.java
@@ -24,4 +24,11 @@ class RawitSampleTest {
         assertEquals(10, p.getX());
         assertEquals(20, p.getY());
     }
+
+    @Test
+    void recordConstructor() {
+        Coord c = Coord.constructor().x(1).y(2).construct();
+        assertEquals(1, c.x());
+        assertEquals(2, c.y());
+    }
 }

--- a/samples/maven-sample/src/main/java/com/example/rawit/Coord.java
+++ b/samples/maven-sample/src/main/java/com/example/rawit/Coord.java
@@ -1,0 +1,6 @@
+package com.example.rawit;
+
+import rawit.Constructor;
+
+@Constructor
+public record Coord(int x, int y) {}

--- a/samples/maven-sample/src/test/java/com/example/rawit/RawitSampleTest.java
+++ b/samples/maven-sample/src/test/java/com/example/rawit/RawitSampleTest.java
@@ -24,4 +24,11 @@ class RawitSampleTest {
         assertEquals(10, p.getX());
         assertEquals(20, p.getY());
     }
+
+    @Test
+    void recordConstructor() {
+        Coord c = Coord.constructor().x(1).y(2).construct();
+        assertEquals(1, c.x());
+        assertEquals(2, c.y());
+    }
 }

--- a/src/main/java/rawit/Constructor.java
+++ b/src/main/java/rawit/Constructor.java
@@ -10,6 +10,6 @@ import java.lang.annotation.Target;
  * Injects a {@code public static constructor()} entry point and a staged construction chain
  * into the enclosing class. The chain ends with {@code .construct()}.
  */
-@Target(ElementType.CONSTRUCTOR)
+@Target({ElementType.CONSTRUCTOR, ElementType.TYPE})
 @Retention(RetentionPolicy.SOURCE)
 public @interface Constructor { }

--- a/src/main/java/rawit/processors/RawitAnnotationProcessor.java
+++ b/src/main/java/rawit/processors/RawitAnnotationProcessor.java
@@ -93,11 +93,16 @@ public class RawitAnnotationProcessor extends AbstractProcessor {
                     continue; // skip invalid elements
                 }
 
-                if (!(element instanceof ExecutableElement exec)) {
+                final AnnotatedMethod model;
+                if (element instanceof TypeElement typeElement
+                        && typeElement.getKind() == ElementKind.RECORD) {
+                    model = buildAnnotatedMethodFromRecord(typeElement);
+                } else if (element instanceof ExecutableElement exec) {
+                    model = buildAnnotatedMethod(exec);
+                } else {
                     continue;
                 }
 
-                final AnnotatedMethod model = buildAnnotatedMethod(exec);
                 if (model != null) {
                     validMethods.add(model);
                     if (debug) {
@@ -267,6 +272,59 @@ public class RawitAnnotationProcessor extends AbstractProcessor {
                 returnTypeDescriptor,
                 checkedExceptions,
                 accessFlags);
+    }
+
+    /**
+     * Builds an {@link AnnotatedMethod} from a {@code @Constructor}-annotated record type.
+     *
+     * <p>Derives the canonical constructor parameters from the record's components in
+     * declaration order. Sets {@code methodName="<init>"}, {@code isConstructor=true},
+     * {@code isConstructorAnnotation=true}, {@code returnTypeDescriptor="V"}, and
+     * {@code checkedExceptions=List.of()}.
+     *
+     * @param recordElement the validated record type element
+     * @return the model
+     */
+    private AnnotatedMethod buildAnnotatedMethodFromRecord(final TypeElement recordElement) {
+        final String enclosingClassName = toBinaryName(recordElement);
+
+        final List<Parameter> parameters = new ArrayList<>();
+        for (final RecordComponentElement comp : recordElement.getRecordComponents()) {
+            final String name = comp.getSimpleName().toString();
+            final String descriptor = toTypeDescriptor(comp.asType());
+            parameters.add(new Parameter(name, descriptor));
+        }
+
+        final int accessFlags = resolveRecordAccessFlags(recordElement);
+
+        return new AnnotatedMethod(
+                enclosingClassName,
+                "<init>",
+                false,
+                true,
+                true,
+                parameters,
+                "V",
+                List.of(),
+                accessFlags);
+    }
+
+    /**
+     * Resolves ASM-compatible access flags from a record type's modifiers.
+     *
+     * <p>The canonical constructor of a record inherits the visibility of the record type
+     * itself (public record → ACC_PUBLIC, protected record → ACC_PROTECTED, etc.).
+     *
+     * @param typeElement the record type element
+     * @return the ASM access flags
+     */
+    private static int resolveRecordAccessFlags(final TypeElement typeElement) {
+        final Set<Modifier> mods = typeElement.getModifiers();
+        int flags = 0;
+        if (mods.contains(Modifier.PUBLIC))    flags |= 0x0001; // ACC_PUBLIC
+        if (mods.contains(Modifier.PROTECTED)) flags |= 0x0004; // ACC_PROTECTED
+        // package-private: no visibility flag set (flags == 0)
+        return flags;
     }
 
     /**

--- a/src/main/java/rawit/processors/validation/ElementValidator.java
+++ b/src/main/java/rawit/processors/validation/ElementValidator.java
@@ -8,6 +8,7 @@ import javax.lang.model.element.*;
 import javax.lang.model.type.TypeKind;
 import javax.tools.Diagnostic;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Validates elements annotated with {@code @Invoker} or {@code @Constructor}.
@@ -39,7 +40,18 @@ public class ElementValidator {
         if (hasInvoker) {
             return validateInvoker(element, messager);
         } else if (hasConstructor) {
-            return validateConstructor(element, messager);
+            if (element instanceof TypeElement te && te.getKind() == ElementKind.RECORD) {
+                return validateConstructorOnType(element, messager);
+            }
+            if (element.getKind() == ElementKind.CONSTRUCTOR) {
+                return validateConstructorOnExecutable(element, messager);
+            }
+            // Not a record type and not a constructor → error
+            messager.printMessage(
+                    Diagnostic.Kind.ERROR,
+                    "@Constructor on a type is only supported for records",
+                    element);
+            return ValidationResult.invalid();
         }
 
         // No recognised annotation — nothing to validate
@@ -98,10 +110,10 @@ public class ElementValidator {
     }
 
     // -------------------------------------------------------------------------
-    // @Constructor validation
+    // @Constructor validation (ExecutableElement — explicit constructor)
     // -------------------------------------------------------------------------
 
-    private ValidationResult validateConstructor(final Element element, final Messager messager) {
+    private ValidationResult validateConstructorOnExecutable(final Element element, final Messager messager) {
         boolean hasError = false;
 
         // Requirement 15.1 — must be a CONSTRUCTOR
@@ -142,6 +154,48 @@ public class ElementValidator {
                     "a parameterless overload named 'constructor' already exists on this class",
                     element);
             hasError = true;
+        }
+
+        return hasError ? ValidationResult.invalid() : ValidationResult.valid();
+    }
+
+    // -------------------------------------------------------------------------
+    // @Constructor validation (TypeElement — record type)
+    // -------------------------------------------------------------------------
+
+    private ValidationResult validateConstructorOnType(final Element element, final Messager messager) {
+        boolean hasError = false;
+
+        // Requirement 2.3 — must be a RECORD (not CLASS, INTERFACE, ENUM)
+        if (!(element instanceof TypeElement typeElement)
+                || typeElement.getKind() != ElementKind.RECORD) {
+            messager.printMessage(
+                    Diagnostic.Kind.ERROR,
+                    "@Constructor on a type is only supported for records",
+                    element);
+            hasError = true;
+        }
+
+        if (element instanceof TypeElement typeElement
+                && typeElement.getKind() == ElementKind.RECORD) {
+
+            // Requirement 2.2 — record must have ≥ 1 record component
+            if (typeElement.getRecordComponents().isEmpty()) {
+                messager.printMessage(
+                        Diagnostic.Kind.ERROR,
+                        "staged construction requires at least one record component",
+                        element);
+                hasError = true;
+            }
+
+            // Requirement 2.4 — no existing zero-param static method named "constructor"
+            if (typeHasZeroParamStaticMethod(typeElement, "constructor")) {
+                messager.printMessage(
+                        Diagnostic.Kind.ERROR,
+                        "a parameterless overload named 'constructor' already exists",
+                        element);
+                hasError = true;
+            }
         }
 
         return hasError ? ValidationResult.invalid() : ValidationResult.valid();
@@ -193,6 +247,27 @@ public class ElementValidator {
             final ExecutableElement candidate = (ExecutableElement) enclosed;
             if (candidate.getSimpleName().contentEquals(methodName)
                     && candidate.getParameters().isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Scans the enclosed elements of the given {@link TypeElement} for a zero-parameter
+     * static method with the given name. Used for record-type conflict detection where
+     * the type element IS the enclosing element (unlike the constructor case).
+     */
+    private boolean typeHasZeroParamStaticMethod(final TypeElement typeElement,
+                                                  final String methodName) {
+        for (final Element enclosed : typeElement.getEnclosedElements()) {
+            if (enclosed.getKind() != ElementKind.METHOD) {
+                continue;
+            }
+            final ExecutableElement candidate = (ExecutableElement) enclosed;
+            if (candidate.getSimpleName().contentEquals(methodName)
+                    && candidate.getParameters().isEmpty()
+                    && candidate.getModifiers().contains(Modifier.STATIC)) {
                 return true;
             }
         }

--- a/src/test/java/rawit/SlowTestsBugConditionExplorationTest.java
+++ b/src/test/java/rawit/SlowTestsBugConditionExplorationTest.java
@@ -78,27 +78,27 @@ class SlowTestsBugConditionExplorationTest {
     /**
      * Validates: Requirements 2.1
      *
-     * <p>Asserts that all 9 property methods in {@code ElementValidatorPropertyTest}
+     * <p>Asserts that all 12 property methods in {@code ElementValidatorPropertyTest}
      * have {@code tries = 5}. FAILS on unfixed code (currently tries=100).
      */
     @Test
     void elementValidatorPropertyTest_allPropertiesHaveTries5() {
         assertTriesAndCount(
                 loadClass("rawit.processors.validation.ElementValidatorPropertyTest"),
-                EXPECTED_TRIES, 9);
+                EXPECTED_TRIES, 12);
     }
 
     /**
      * Validates: Requirements 2.2
      *
-     * <p>Asserts that all 5 property methods in {@code BytecodeInjectorPropertyTest}
+     * <p>Asserts that all 7 property methods in {@code BytecodeInjectorPropertyTest}
      * have {@code tries = 5}. FAILS on unfixed code (currently tries=100).
      */
     @Test
     void bytecodeInjectorPropertyTest_allPropertiesHaveTries5() {
         assertTriesAndCount(
                 loadClass("rawit.processors.inject.BytecodeInjectorPropertyTest"),
-                EXPECTED_TRIES, 5);
+                EXPECTED_TRIES, 7);
     }
 
     /**
@@ -117,13 +117,13 @@ class SlowTestsBugConditionExplorationTest {
     /**
      * Validates: Requirements 2.4
      *
-     * <p>Asserts that all 3 property methods in {@code RawitAnnotationProcessorConstructorPropertyTest}
+     * <p>Asserts that all 9 property methods in {@code RawitAnnotationProcessorConstructorPropertyTest}
      * have {@code tries = 5}. FAILS on unfixed code (currently tries=10).
      */
     @Test
     void rawitAnnotationProcessorConstructorPropertyTest_allPropertiesHaveTries5() {
         assertTriesAndCount(
                 loadClass("rawit.processors.RawitAnnotationProcessorConstructorPropertyTest"),
-                EXPECTED_TRIES, 3);
+                EXPECTED_TRIES, 9);
     }
 }

--- a/src/test/java/rawit/processors/RawitAnnotationProcessorConstructorPropertyTest.java
+++ b/src/test/java/rawit/processors/RawitAnnotationProcessorConstructorPropertyTest.java
@@ -39,6 +39,36 @@ class RawitAnnotationProcessorConstructorPropertyTest {
         return Arbitraries.integers().between(1, 3);
     }
 
+    /** Number of record components (1–3) for Property 1. */
+    @Provide
+    Arbitrary<Integer> recordComponentCount() {
+        return Arbitraries.integers().between(1, 3);
+    }
+
+    /**
+     * Represents a record component type with its Java source declaration and the expected
+     * Java class after compilation (used for reflection-based verification).
+     */
+    private record ComponentType(String javaSource, Class<?> expectedClass) {}
+
+    /** Arbitrary that picks from a set of representative component types for Property 5. */
+    @Provide
+    Arbitrary<ComponentType> componentType() {
+        return Arbitraries.of(
+                new ComponentType("int", int.class),
+                new ComponentType("long", long.class),
+                new ComponentType("boolean", boolean.class),
+                new ComponentType("double", double.class),
+                new ComponentType("byte", byte.class),
+                new ComponentType("char", char.class),
+                new ComponentType("short", short.class),
+                new ComponentType("float", float.class),
+                new ComponentType("String", String.class),
+                new ComponentType("int[]", int[].class),
+                new ComponentType("String[]", String[].class)
+        );
+    }
+
     // =========================================================================
     // Compilation infrastructure (mirrors RawitAnnotationProcessorIntegrationTest)
     // =========================================================================
@@ -167,6 +197,21 @@ class RawitAnnotationProcessorConstructorPropertyTest {
                         });
             }
         } catch (final IOException ignored) {}
+    }
+
+    /**
+     * Builds a source string for a {@code @Constructor}-annotated record with {@code n}
+     * int components named c0, c1, ..., c(n-1).
+     */
+    private static String buildRecordSource(final String recordName, final int componentCount) {
+        final StringBuilder components = new StringBuilder();
+        for (int i = 0; i < componentCount; i++) {
+            if (i > 0) components.append(", ");
+            components.append("int c").append(i);
+        }
+        return "import rawit.Constructor;\n" +
+               "@Constructor\n" +
+               "public record " + recordName + "(" + components + ") {}\n";
     }
 
     /**
@@ -363,6 +408,629 @@ class RawitAnnotationProcessorConstructorPropertyTest {
             assertNotNull(result, "construct() must return a non-null instance");
             assertInstanceOf(cls, result,
                     "construct() result must be an instance of " + cls.getName());
+        } finally {
+            deleteRecursively(outputDir);
+        }
+    }
+
+    // =========================================================================
+    // Property 1: Record AnnotatedMethod construction correctness
+    // Feature: record-constructor-support, Property 1: Record AnnotatedMethod construction correctness
+    // =========================================================================
+
+    /**
+     * For any record type with N ≥ 1 components, building an AnnotatedMethod from that record
+     * SHALL produce a model where enclosingClassName equals the slash-separated binary name of
+     * the record, methodName equals "&lt;init&gt;", isConstructor is true,
+     * isConstructorAnnotation is true, and parameters is a list of N Parameter entries whose
+     * names and type descriptors match the record components in declaration order.
+     *
+     * <p>We verify this indirectly by compiling a @Constructor-annotated record through the
+     * processor and checking the generated staged API: the entry point is {@code constructor()}
+     * (proving isConstructorAnnotation=true), the terminal is {@code construct()} (proving
+     * isConstructor=true with @Constructor), and there are exactly N stage methods whose names
+     * match the record component names in declaration order.
+     *
+     * <p>Validates: Requirements 3.2, 3.3, 3.4
+     */
+    @Property(tries = 5)
+    void property1_recordAnnotatedMethodConstructionCorrectness(
+            @ForAll("recordComponentCount") int n
+    ) throws Exception {
+        // Feature: record-constructor-support, Property 1: Record AnnotatedMethod construction correctness
+        final String recordName = "RecProp1_" + n + "_" + Long.toHexString(System.nanoTime() & 0xFFFFFFFFL);
+        final String source = buildRecordSource(recordName, n);
+
+        final Path outputDir = Files.createTempDirectory("prop1_rec_");
+        try (final URLClassLoader loader = compileAndLoad(recordName, source, outputDir)) {
+            final Class<?> recordClass = loader.loadClass(recordName);
+
+            // 1. Verify constructor() entry point exists (proves enclosingClassName is correct
+            //    and isConstructorAnnotation=true — the processor only generates constructor()
+            //    for @Constructor-annotated elements)
+            final Method entryPoint = recordClass.getMethod("constructor");
+            assertNotNull(entryPoint,
+                    "Record " + recordName + " must have a zero-arg 'constructor()' entry point");
+            assertTrue(Modifier.isPublic(entryPoint.getModifiers()),
+                    "'constructor()' must be public");
+            assertTrue(Modifier.isStatic(entryPoint.getModifiers()),
+                    "'constructor()' must be static");
+
+            // 2. Walk the staged chain: constructor().c0(0).c1(0)...c(N-1)(0).construct()
+            //    This verifies parameters match record components in declaration order
+            Object stage = entryPoint.invoke(null);
+
+            for (int i = 0; i < n; i++) {
+                final String componentName = "c" + i;
+                // Find the stage method matching the component name (accepts int)
+                final Method stageMethod = findMethod(stage, componentName, 1);
+                assertNotNull(stageMethod,
+                        "Stage method '" + componentName + "' must exist at position " + i
+                                + " (proves parameter order matches record component order)");
+
+                // Verify the stage method accepts int (matching the record component type)
+                assertEquals(int.class, stageMethod.getParameterTypes()[0],
+                        "Stage method '" + componentName + "' must accept int"
+                                + " (proves type descriptor 'I' was correctly derived)");
+
+                stageMethod.setAccessible(true);
+                stage = stageMethod.invoke(stage, i);
+            }
+
+            // 3. Verify the terminal method is construct() (proves isConstructor=true and
+            //    isConstructorAnnotation=true — @Constructor uses construct(), not invoke())
+            final Method constructMethod = findMethod(stage, "construct", 0);
+            assertNotNull(constructMethod,
+                    "Terminal must have 'construct()' (proves isConstructor=true, "
+                            + "isConstructorAnnotation=true, methodName='<init>')");
+
+            // 4. Verify construct() returns the record type (proves enclosingClassName is correct)
+            assertEquals(recordClass, constructMethod.getReturnType(),
+                    "construct() must return " + recordName);
+
+            // 5. Invoke and verify the result is a valid record instance
+            constructMethod.setAccessible(true);
+            final Object result = constructMethod.invoke(stage);
+            assertNotNull(result, "construct() must return a non-null instance");
+            assertInstanceOf(recordClass, result,
+                    "construct() result must be an instance of " + recordName);
+
+            // 6. Verify the record component values match what we passed through the chain
+            for (int i = 0; i < n; i++) {
+                final Method accessor = recordClass.getMethod("c" + i);
+                assertEquals(i, accessor.invoke(result),
+                        "Record component c" + i + " must equal " + i);
+            }
+        } finally {
+            deleteRecursively(outputDir);
+        }
+    }
+
+    // =========================================================================
+    // Property 5: Type descriptor correctness for record components
+    // Feature: record-constructor-support, Property 5: Type descriptor correctness for record components
+    // =========================================================================
+
+    /**
+     * For any record component type — whether primitive, reference, or array — the
+     * toTypeDescriptor() method SHALL produce the correct JVM type descriptor.
+     *
+     * <p>We verify this by compiling a @Constructor-annotated record with a single component
+     * of the given type through the processor, then checking via reflection that the generated
+     * stage method accepts the correct Java type (which proves the processor derived the correct
+     * JVM type descriptor from the record component).
+     *
+     * <p>Validates: Requirements 7.1, 7.2, 7.3
+     */
+    @Property(tries = 5)
+    void property5_typeDescriptorCorrectnessForRecordComponents(
+            @ForAll("componentType") ComponentType compType
+    ) throws Exception {
+        // Feature: record-constructor-support, Property 5: Type descriptor correctness for record components
+        final String recordName = "RecProp5_" + compType.javaSource().replaceAll("[^a-zA-Z0-9]", "")
+                + "_" + Long.toHexString(System.nanoTime() & 0xFFFFFFFFL);
+
+        final String source = "import rawit.Constructor;\n" +
+                "@Constructor\n" +
+                "public record " + recordName + "(" + compType.javaSource() + " value) {}\n";
+
+        final Path outputDir = Files.createTempDirectory("prop5_rec_");
+        try (final URLClassLoader loader = compileAndLoad(recordName, source, outputDir)) {
+            final Class<?> recordClass = loader.loadClass(recordName);
+
+            // Call the constructor() entry point
+            final Method entryPoint = recordClass.getMethod("constructor");
+            assertNotNull(entryPoint,
+                    "Record " + recordName + " must have a 'constructor()' entry point");
+
+            final Object stage = entryPoint.invoke(null);
+
+            // Find the stage method for the "value" component
+            final Method valueMethod = findMethod(stage, "value", 1);
+            assertNotNull(valueMethod,
+                    "Stage method 'value' must exist for component type " + compType.javaSource());
+
+            // Verify the parameter type matches the expected Java class
+            // This proves toTypeDescriptor() produced the correct JVM descriptor:
+            //   int → "I", long → "J", boolean → "Z", String → "Ljava/lang/String;",
+            //   int[] → "[I", String[] → "[Ljava/lang/String;", etc.
+            assertEquals(compType.expectedClass(), valueMethod.getParameterTypes()[0],
+                    "Stage method 'value' must accept " + compType.expectedClass().getName()
+                            + " for component type " + compType.javaSource()
+                            + " (proves correct JVM type descriptor)");
+        } finally {
+            deleteRecursively(outputDir);
+        }
+    }
+
+    // =========================================================================
+    // Reflection helper
+    // =========================================================================
+
+    /**
+     * Finds a method by name and parameter count on the target object, searching both
+     * the concrete class and its interfaces.
+     */
+    private static Method findMethod(final Object target, final String methodName,
+                                      final int paramCount) {
+        // Search concrete class methods first
+        for (final Method m : target.getClass().getMethods()) {
+            if (methodName.equals(m.getName()) && m.getParameterCount() == paramCount) {
+                return m;
+            }
+        }
+        // Search declared interfaces
+        for (final Class<?> iface : target.getClass().getInterfaces()) {
+            for (final Method m : iface.getMethods()) {
+                if (methodName.equals(m.getName()) && m.getParameterCount() == paramCount) {
+                    return m;
+                }
+            }
+        }
+        return null;
+    }
+
+    // =========================================================================
+    // Multi-source compilation helpers (for Property 10)
+    // =========================================================================
+
+    private static void compileMultipleWithoutProcessor(final List<String> classNames,
+                                                         final List<String> sources,
+                                                         final Path outputDir) throws Exception {
+        compileMultiple(classNames, sources, outputDir, List.of(), List.of("-proc:none"));
+    }
+
+    private static void compileMultipleWithProcessor(final List<String> classNames,
+                                                      final List<String> sources,
+                                                      final Path outputDir) throws Exception {
+        compileMultiple(classNames, sources, outputDir,
+                List.of(new RawitAnnotationProcessor()),
+                List.of("-proc:only", "-classpath", buildClasspath(outputDir)));
+
+        final java.util.Set<String> originalNames = new java.util.HashSet<>();
+        for (final String cn : classNames) {
+            originalNames.add(cn.replace('.', File.separatorChar) + ".java");
+        }
+
+        final java.util.List<File> generatedJavaFiles = new java.util.ArrayList<>();
+        try (final var stream = Files.walk(outputDir)) {
+            stream.filter(p -> p.toString().endsWith(".java"))
+                  .filter(p -> {
+                      final String relative = outputDir.relativize(p).toString();
+                      return !originalNames.contains(relative);
+                  })
+                  .forEach(p -> generatedJavaFiles.add(p.toFile()));
+        }
+
+        if (!generatedJavaFiles.isEmpty()) {
+            final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+            final DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+            try (final StandardJavaFileManager fm =
+                         compiler.getStandardFileManager(diagnostics, null, null)) {
+                fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(outputDir.toFile()));
+                fm.setLocation(StandardLocation.CLASS_PATH, List.of(outputDir.toFile()));
+
+                final java.util.List<JavaFileObject> sourceFiles = new java.util.ArrayList<>();
+                for (final File jf : generatedJavaFiles) {
+                    sourceFiles.add(new SimpleJavaFileObject(jf.toURI(), JavaFileObject.Kind.SOURCE) {
+                        @Override
+                        public CharSequence getCharContent(boolean ignoreEncodingErrors)
+                                throws IOException {
+                            return Files.readString(jf.toPath());
+                        }
+                    });
+                }
+
+                final boolean success = compiler.getTask(
+                        null, fm, diagnostics, List.of("-proc:none"), null, sourceFiles).call();
+                if (!success) {
+                    final StringBuilder sb = new StringBuilder("Generated source compilation failed:\n");
+                    for (final Diagnostic<? extends JavaFileObject> d : diagnostics.getDiagnostics()) {
+                        if (d.getKind() == Diagnostic.Kind.ERROR) {
+                            sb.append("  ERROR: ").append(d.getMessage(null)).append('\n');
+                        }
+                    }
+                    fail(sb.toString());
+                }
+            }
+        }
+    }
+
+    private static void compileMultiple(final List<String> classNames,
+                                         final List<String> sources,
+                                         final Path outputDir,
+                                         final List<Processor> processors,
+                                         final List<String> options) throws Exception {
+        final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertNotNull(compiler, "JavaCompiler not available — run tests with a JDK, not a JRE");
+
+        final DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        try (final StandardJavaFileManager fm =
+                     compiler.getStandardFileManager(diagnostics, null, null)) {
+
+            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(outputDir.toFile()));
+            fm.setLocation(StandardLocation.SOURCE_OUTPUT, List.of(outputDir.toFile()));
+
+            final java.util.List<JavaFileObject> sourceFileObjects = new java.util.ArrayList<>();
+            for (int i = 0; i < classNames.size(); i++) {
+                final String cn = classNames.get(i);
+                final String src = sources.get(i);
+                sourceFileObjects.add(new SimpleJavaFileObject(
+                        URI.create("string:///" + cn.replace('.', '/') + ".java"),
+                        JavaFileObject.Kind.SOURCE) {
+                    @Override
+                    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                        return src;
+                    }
+                });
+            }
+
+            final JavaCompiler.CompilationTask task = compiler.getTask(
+                    null, fm, diagnostics, options, null, sourceFileObjects);
+
+            if (!processors.isEmpty()) {
+                task.setProcessors(processors);
+            }
+
+            final boolean success = task.call();
+            if (!success) {
+                final StringBuilder sb = new StringBuilder("Compilation failed:\n");
+                for (final Diagnostic<? extends JavaFileObject> d : diagnostics.getDiagnostics()) {
+                    if (d.getKind() == Diagnostic.Kind.ERROR) {
+                        sb.append("  ERROR: ").append(d.getMessage(null));
+                        if (d.getSource() != null) {
+                            sb.append(" [in ").append(d.getSource().getName()).append("]");
+                        }
+                        sb.append('\n');
+                    }
+                }
+                fail(sb.toString());
+            }
+        }
+    }
+
+    private static URLClassLoader compileMultipleAndLoad(final List<String> classNames,
+                                                          final List<String> sources,
+                                                          final Path outputDir) throws Exception {
+        compileMultipleWithoutProcessor(classNames, sources, outputDir);
+        compileMultipleWithProcessor(classNames, sources, outputDir);
+        return new URLClassLoader(
+                new URL[]{outputDir.toUri().toURL()},
+                Thread.currentThread().getContextClassLoader());
+    }
+
+    // =========================================================================
+    // Property 6: Code generation produces correct staged API for records
+    // Feature: record-constructor-support, Property 6: Code generation produces correct staged API for records
+    // =========================================================================
+
+    /**
+     * For any record-derived AnnotatedMethod with N parameters, the JavaPoetGenerator pipeline
+     * SHALL produce a Constructor caller class containing N stage interfaces with setter methods
+     * matching the parameter names in order, and a ConstructStageInvoker terminal interface with
+     * a construct() method returning the record type.
+     *
+     * <p>Validates: Requirements 5.1, 5.2, 5.3
+     */
+    @Property(tries = 5)
+    void property6_codeGenerationProducesCorrectStagedApiForRecords(
+            @ForAll("recordComponentCount") int n
+    ) throws Exception {
+        // Feature: record-constructor-support, Property 6: Code generation produces correct staged API for records
+        final String recordName = "RecProp6_" + n + "_" + Long.toHexString(System.nanoTime() & 0xFFFFFFFFL);
+        final String source = buildRecordSource(recordName, n);
+
+        final Path outputDir = Files.createTempDirectory("prop6_rec_");
+        try (final URLClassLoader loader = compileAndLoad(recordName, source, outputDir)) {
+            final Class<?> recordClass = loader.loadClass(recordName);
+
+            // 1. Verify the Constructor caller class exists
+            final Class<?> constructorClass = loader.loadClass("Constructor");
+            assertNotNull(constructorClass,
+                    "A top-level 'Constructor' caller class must be generated for record " + recordName);
+            assertTrue(Modifier.isPublic(constructorClass.getModifiers()),
+                    "Constructor caller class must be public");
+
+            // 2. Walk the staged chain to verify N stage interfaces with correct setter methods
+            Object stage = recordClass.getMethod("constructor").invoke(null);
+
+            for (int i = 0; i < n; i++) {
+                final String componentName = "c" + i;
+
+                // Verify the current stage object implements an interface with the expected setter
+                final Method stageMethod = findMethod(stage, componentName, 1);
+                assertNotNull(stageMethod,
+                        "Stage " + (i + 1) + " must have setter method '" + componentName + "'");
+                assertEquals(int.class, stageMethod.getParameterTypes()[0],
+                        "Stage setter '" + componentName + "' must accept int");
+
+                stageMethod.setAccessible(true);
+                stage = stageMethod.invoke(stage, i);
+            }
+
+            // 3. Verify the terminal interface has construct() returning the record type
+            final Method constructMethod = findMethod(stage, "construct", 0);
+            assertNotNull(constructMethod,
+                    "Terminal stage must have a 'construct()' method (ConstructStageInvoker)");
+            assertEquals(recordClass, constructMethod.getReturnType(),
+                    "construct() must return " + recordName);
+
+            // 4. Verify construct() actually works
+            constructMethod.setAccessible(true);
+            final Object result = constructMethod.invoke(stage);
+            assertNotNull(result, "construct() must return a non-null instance");
+            assertInstanceOf(recordClass, result,
+                    "construct() result must be an instance of " + recordName);
+
+            // 5. Verify no invoke() method exists (this is @Constructor, not @Invoker)
+            final Method invokeMethod = findMethod(stage, "invoke", 0);
+            assertNull(invokeMethod,
+                    "Terminal stage must NOT have an 'invoke()' method — only 'construct()'");
+        } finally {
+            deleteRecursively(outputDir);
+        }
+    }
+
+    // =========================================================================
+    // Property 11: Pipeline integration for record-derived AnnotatedMethod
+    // Feature: record-constructor-support, Property 11: Pipeline integration for record-derived AnnotatedMethod
+    // =========================================================================
+
+    /**
+     * For any AnnotatedMethod built from a record type, the model SHALL successfully pass
+     * through OverloadGroup construction, MergeTreeBuilder.build(), and InvokerClassSpec.build()
+     * without errors, producing a valid merge tree and generated source code.
+     *
+     * <p>We verify this by compiling a @Constructor-annotated record through the full processor
+     * pipeline. Successful compilation proves the AnnotatedMethod passed through OverloadGroup,
+     * MergeTreeBuilder, and InvokerClassSpec without errors.
+     *
+     * <p>Validates: Requirements 4.3
+     */
+    @Property(tries = 5)
+    void property11_pipelineIntegrationForRecordDerivedAnnotatedMethod(
+            @ForAll("recordComponentCount") int n
+    ) throws Exception {
+        // Feature: record-constructor-support, Property 11: Pipeline integration for record-derived AnnotatedMethod
+        final String recordName = "RecProp11_" + n + "_" + Long.toHexString(System.nanoTime() & 0xFFFFFFFFL);
+        final String source = buildRecordSource(recordName, n);
+
+        final Path outputDir = Files.createTempDirectory("prop11_rec_");
+        try (final URLClassLoader loader = compileAndLoad(recordName, source, outputDir)) {
+            final Class<?> recordClass = loader.loadClass(recordName);
+
+            // 1. Verify the Constructor caller class was generated (proves InvokerClassSpec.build() succeeded)
+            final Class<?> constructorClass = loader.loadClass("Constructor");
+            assertNotNull(constructorClass,
+                    "Constructor caller class must be generated (proves pipeline integration)");
+
+            // 2. Verify the entry point exists (proves BytecodeInjector succeeded)
+            final Method entryPoint = recordClass.getMethod("constructor");
+            assertNotNull(entryPoint,
+                    "constructor() entry point must exist (proves bytecode injection succeeded)");
+
+            // 3. Walk the full chain to verify the entire pipeline produced working code
+            Object stage = entryPoint.invoke(null);
+            for (int i = 0; i < n; i++) {
+                final Method stageMethod = findMethod(stage, "c" + i, 1);
+                assertNotNull(stageMethod,
+                        "Stage method 'c" + i + "' must exist (proves MergeTreeBuilder produced correct tree)");
+                stageMethod.setAccessible(true);
+                stage = stageMethod.invoke(stage, i);
+            }
+
+            final Method constructMethod = findMethod(stage, "construct", 0);
+            assertNotNull(constructMethod,
+                    "construct() must exist (proves OverloadGroup → MergeTree → CodeGen pipeline worked)");
+
+            constructMethod.setAccessible(true);
+            final Object result = constructMethod.invoke(stage);
+            assertNotNull(result, "construct() must return a non-null instance");
+            assertInstanceOf(recordClass, result,
+                    "construct() result must be an instance of " + recordName);
+        } finally {
+            deleteRecursively(outputDir);
+        }
+    }
+
+    // =========================================================================
+    // Property 9: Backward compatibility for regular class constructors
+    // Feature: record-constructor-support, Property 9: Backward compatibility for regular class constructors
+    // =========================================================================
+
+    /**
+     * For any regular (non-record) class constructor annotated with @Constructor, the
+     * ElementValidator SHALL apply the same validation rules as before this feature, and the
+     * RawitAnnotationProcessor SHALL build the AnnotatedMethod using the existing
+     * ExecutableElement-based code path, producing identical output to the pre-feature behavior.
+     *
+     * <p>We verify this by compiling a regular class with @Constructor on its constructor and
+     * checking that the staged API works identically to the pre-feature behavior: constructor()
+     * entry point, stage methods matching parameter names, and construct() terminal.
+     *
+     * <p>Validates: Requirements 1.2, 8.1, 8.2
+     */
+    @Property(tries = 5)
+    void property9_backwardCompatibilityForRegularClassConstructors(
+            @ForAll("paramCount") int n
+    ) throws Exception {
+        // Feature: record-constructor-support, Property 9: Backward compatibility for regular class constructors
+        final String className = "RegProp9_" + n + "_" + Long.toHexString(System.nanoTime() & 0xFFFFFFFFL);
+        final String source = buildConstructorSource(className, n);
+
+        final Path outputDir = Files.createTempDirectory("prop9_reg_");
+        try (final URLClassLoader loader = compileAndLoad(className, source, outputDir)) {
+            final Class<?> cls = loader.loadClass(className);
+
+            // 1. Verify constructor() entry point exists (backward compatible behavior)
+            final Method entryPoint = cls.getMethod("constructor");
+            assertNotNull(entryPoint,
+                    "Regular class " + className + " must have constructor() entry point");
+            assertTrue(Modifier.isPublic(entryPoint.getModifiers()),
+                    "constructor() must be public");
+            assertTrue(Modifier.isStatic(entryPoint.getModifiers()),
+                    "constructor() must be static");
+
+            // 2. Walk the staged chain: constructor().p0(0).p1(0)...p(N-1)(0).construct()
+            Object stage = entryPoint.invoke(null);
+            for (int i = 0; i < n; i++) {
+                final String paramName = "p" + i;
+                final Method stageMethod = findMethod(stage, paramName, 1);
+                assertNotNull(stageMethod,
+                        "Stage method '" + paramName + "' must exist at position " + i);
+                assertEquals(int.class, stageMethod.getParameterTypes()[0],
+                        "Stage method '" + paramName + "' must accept int");
+                stageMethod.setAccessible(true);
+                stage = stageMethod.invoke(stage, i + 1);
+            }
+
+            // 3. Verify terminal is construct() (not invoke() — this is @Constructor)
+            final Method constructMethod = findMethod(stage, "construct", 0);
+            assertNotNull(constructMethod,
+                    "Terminal must have 'construct()' method");
+            assertEquals(cls, constructMethod.getReturnType(),
+                    "construct() must return " + className);
+
+            // 4. Invoke and verify the result
+            constructMethod.setAccessible(true);
+            final Object result = constructMethod.invoke(stage);
+            assertNotNull(result, "construct() must return a non-null instance");
+            assertInstanceOf(cls, result,
+                    "construct() result must be an instance of " + className);
+
+            // 5. Verify field values match what we passed through the chain
+            for (int i = 0; i < n; i++) {
+                final Object fieldValue = cls.getField("p" + i).get(result);
+                assertEquals(i + 1, fieldValue,
+                        "Field p" + i + " must equal " + (i + 1));
+            }
+        } finally {
+            deleteRecursively(outputDir);
+        }
+    }
+
+    // =========================================================================
+    // Property 10: Independent processing of records and regular classes
+    // Feature: record-constructor-support, Property 10: Independent processing of records and regular classes
+    // =========================================================================
+
+    /**
+     * For any compilation round containing both a @Constructor-annotated record type and a
+     * @Constructor-annotated regular class constructor, the processor SHALL produce correct
+     * AnnotatedMethod models for both, and neither SHALL interfere with the other's overload
+     * grouping, code generation, or bytecode injection.
+     *
+     * <p>Validates: Requirements 8.3
+     */
+    @Property(tries = 5)
+    void property10_independentProcessingOfRecordsAndRegularClasses(
+            @ForAll("recordComponentCount") int n
+    ) throws Exception {
+        // Feature: record-constructor-support, Property 10: Independent processing of records and regular classes
+        final String suffix = Long.toHexString(System.nanoTime() & 0xFFFFFFFFL);
+
+        // Use different packages so each gets its own independent Constructor caller class
+        final String recordPkg = "recpkg" + suffix;
+        final String classPkg = "clspkg" + suffix;
+
+        // Build record source with n int components
+        final StringBuilder recComponents = new StringBuilder();
+        for (int i = 0; i < n; i++) {
+            if (i > 0) recComponents.append(", ");
+            recComponents.append("int c").append(i);
+        }
+        final String recordSource =
+                "package " + recordPkg + ";\n" +
+                "import rawit.Constructor;\n" +
+                "@Constructor\n" +
+                "public record Rec(" + recComponents + ") {}\n";
+
+        // Build class source with n int parameters
+        final StringBuilder clsFields = new StringBuilder();
+        final StringBuilder clsParams = new StringBuilder();
+        final StringBuilder clsAssignments = new StringBuilder();
+        for (int i = 0; i < n; i++) {
+            clsFields.append("    public final int p").append(i).append(";\n");
+            if (i > 0) clsParams.append(", ");
+            clsParams.append("int p").append(i);
+            clsAssignments.append("        this.p").append(i).append(" = p").append(i).append(";\n");
+        }
+        final String classSource =
+                "package " + classPkg + ";\n" +
+                "import rawit.Constructor;\n" +
+                "public class Cls {\n" +
+                clsFields +
+                "    @Constructor\n" +
+                "    public Cls(" + clsParams + ") {\n" +
+                clsAssignments +
+                "    }\n" +
+                "}\n";
+
+        final Path outputDir = Files.createTempDirectory("prop10_both_");
+        try (final URLClassLoader loader = compileMultipleAndLoad(
+                List.of(recordPkg + ".Rec", classPkg + ".Cls"),
+                List.of(recordSource, classSource),
+                outputDir)) {
+
+            // --- Verify the record's staged API ---
+            final Class<?> recordClass = loader.loadClass(recordPkg + ".Rec");
+            Object recStage = recordClass.getMethod("constructor").invoke(null);
+            for (int i = 0; i < n; i++) {
+                final Method m = findMethod(recStage, "c" + i, 1);
+                assertNotNull(m, "Record stage method 'c" + i + "' must exist");
+                m.setAccessible(true);
+                recStage = m.invoke(recStage, i + 10);
+            }
+            final Method recConstruct = findMethod(recStage, "construct", 0);
+            assertNotNull(recConstruct, "Record terminal must have construct()");
+            recConstruct.setAccessible(true);
+            final Object recResult = recConstruct.invoke(recStage);
+            assertNotNull(recResult, "Record construct() must return non-null");
+            assertInstanceOf(recordClass, recResult, "Record result must be correct type");
+            for (int i = 0; i < n; i++) {
+                assertEquals(i + 10, recordClass.getMethod("c" + i).invoke(recResult),
+                        "Record component c" + i + " must equal " + (i + 10));
+            }
+
+            // --- Verify the regular class's staged API ---
+            final Class<?> clsClass = loader.loadClass(classPkg + ".Cls");
+            Object clsStage = clsClass.getMethod("constructor").invoke(null);
+            for (int i = 0; i < n; i++) {
+                final Method m = findMethod(clsStage, "p" + i, 1);
+                assertNotNull(m, "Class stage method 'p" + i + "' must exist");
+                m.setAccessible(true);
+                clsStage = m.invoke(clsStage, i + 20);
+            }
+            final Method clsConstruct = findMethod(clsStage, "construct", 0);
+            assertNotNull(clsConstruct, "Class terminal must have construct()");
+            clsConstruct.setAccessible(true);
+            final Object clsResult = clsConstruct.invoke(clsStage);
+            assertNotNull(clsResult, "Class construct() must return non-null");
+            assertInstanceOf(clsClass, clsResult, "Class result must be correct type");
+            for (int i = 0; i < n; i++) {
+                assertEquals(i + 20, clsClass.getField("p" + i).get(clsResult),
+                        "Class field p" + i + " must equal " + (i + 20));
+            }
         } finally {
             deleteRecursively(outputDir);
         }

--- a/src/test/java/rawit/processors/RawitAnnotationProcessorIntegrationTest.java
+++ b/src/test/java/rawit/processors/RawitAnnotationProcessorIntegrationTest.java
@@ -208,6 +208,154 @@ class RawitAnnotationProcessorIntegrationTest {
         return invoke(target, methodName, new Class<?>[]{String.class}, arg);
     }
 
+    private static Object invokeBoolean(final Object target, final String methodName,
+                                         final boolean arg) throws Exception {
+        return invoke(target, methodName, new Class<?>[]{boolean.class}, arg);
+    }
+
+    // =========================================================================
+    // Multi-source compilation helpers (for tests with multiple source files)
+    // =========================================================================
+
+    /**
+     * Compiles multiple source files into {@code outputDir} without any annotation processor.
+     */
+    private static void compileMultipleWithoutProcessor(final List<String> classNames,
+                                                         final List<String> sources,
+                                                         final Path outputDir) throws Exception {
+        compileMultiple(classNames, sources, outputDir, List.of(), List.of("-proc:none"));
+    }
+
+    /**
+     * Runs the processor in {@code -proc:only} mode on multiple source files, then compiles
+     * the generated source files without the processor.
+     */
+    private static void compileMultipleWithProcessor(final List<String> classNames,
+                                                      final List<String> sources,
+                                                      final Path outputDir) throws Exception {
+        // Step 1: Run processor in proc-only mode
+        compileMultiple(classNames, sources, outputDir,
+                List.of(new RawitAnnotationProcessor()),
+                List.of("-proc:only", "-classpath", buildClasspath(outputDir)));
+
+        // Step 2: Compile the generated .java files without the processor
+        // Build set of original source file names (may include package paths)
+        final java.util.Set<String> originalNames = new java.util.HashSet<>();
+        for (final String cn : classNames) {
+            originalNames.add(cn.replace('.', File.separatorChar) + ".java");
+        }
+
+        // Walk the output directory to find all generated .java files (including in subdirs)
+        final java.util.List<java.io.File> generatedJavaFiles = new java.util.ArrayList<>();
+        try (final var stream = java.nio.file.Files.walk(outputDir)) {
+            stream.filter(p -> p.toString().endsWith(".java"))
+                  .filter(p -> {
+                      final String relative = outputDir.relativize(p).toString();
+                      return !originalNames.contains(relative);
+                  })
+                  .forEach(p -> generatedJavaFiles.add(p.toFile()));
+        }
+
+        if (!generatedJavaFiles.isEmpty()) {
+            final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+            final DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+            try (final StandardJavaFileManager fm =
+                         compiler.getStandardFileManager(diagnostics, null, null)) {
+                fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(outputDir.toFile()));
+                fm.setLocation(StandardLocation.CLASS_PATH, List.of(outputDir.toFile()));
+
+                final java.util.List<JavaFileObject> sourceFiles = new java.util.ArrayList<>();
+                for (final java.io.File jf : generatedJavaFiles) {
+                    sourceFiles.add(new SimpleJavaFileObject(jf.toURI(), JavaFileObject.Kind.SOURCE) {
+                        @Override
+                        public CharSequence getCharContent(boolean ignoreEncodingErrors)
+                                throws java.io.IOException {
+                            return java.nio.file.Files.readString(jf.toPath());
+                        }
+                    });
+                }
+
+                final boolean success = compiler.getTask(
+                        null, fm, diagnostics, List.of("-proc:none"), null, sourceFiles).call();
+                if (!success) {
+                    final StringBuilder sb = new StringBuilder("Generated source compilation failed:\n");
+                    for (final Diagnostic<? extends JavaFileObject> d : diagnostics.getDiagnostics()) {
+                        if (d.getKind() == Diagnostic.Kind.ERROR) {
+                            sb.append("  ERROR: ").append(d.getMessage(null)).append('\n');
+                        }
+                    }
+                    fail(sb.toString());
+                }
+            }
+        }
+    }
+
+    private static void compileMultiple(final List<String> classNames,
+                                         final List<String> sources,
+                                         final Path outputDir,
+                                         final List<Processor> processors,
+                                         final List<String> options) throws Exception {
+        final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertNotNull(compiler, "JavaCompiler not available — run tests with a JDK, not a JRE");
+
+        final DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        try (final StandardJavaFileManager fm =
+                     compiler.getStandardFileManager(diagnostics, null, null)) {
+
+            fm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(outputDir.toFile()));
+            fm.setLocation(StandardLocation.SOURCE_OUTPUT, List.of(outputDir.toFile()));
+
+            final java.util.List<JavaFileObject> sourceFileObjects = new java.util.ArrayList<>();
+            for (int i = 0; i < classNames.size(); i++) {
+                final String cn = classNames.get(i);
+                final String src = sources.get(i);
+                sourceFileObjects.add(new SimpleJavaFileObject(
+                        URI.create("string:///" + cn.replace('.', '/') + ".java"),
+                        JavaFileObject.Kind.SOURCE) {
+                    @Override
+                    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                        return src;
+                    }
+                });
+            }
+
+            final JavaCompiler.CompilationTask task = compiler.getTask(
+                    null, fm, diagnostics, options, null, sourceFileObjects);
+
+            if (!processors.isEmpty()) {
+                task.setProcessors(processors);
+            }
+
+            final boolean success = task.call();
+            if (!success) {
+                final StringBuilder sb = new StringBuilder("Compilation failed:\n");
+                for (final Diagnostic<? extends JavaFileObject> d : diagnostics.getDiagnostics()) {
+                    if (d.getKind() == Diagnostic.Kind.ERROR) {
+                        sb.append("  ERROR: ").append(d.getMessage(null));
+                        if (d.getSource() != null) {
+                            sb.append(" [in ").append(d.getSource().getName()).append("]");
+                        }
+                        sb.append('\n');
+                    }
+                }
+                fail(sb.toString());
+            }
+        }
+    }
+
+    /**
+     * Runs all compilation passes for multiple source files and returns a {@link URLClassLoader}.
+     */
+    private static URLClassLoader compileMultipleAndLoad(final List<String> classNames,
+                                                          final List<String> sources,
+                                                          final Path outputDir) throws Exception {
+        compileMultipleWithoutProcessor(classNames, sources, outputDir);
+        compileMultipleWithProcessor(classNames, sources, outputDir);
+        return new URLClassLoader(
+                new URL[]{outputDir.toUri().toURL()},
+                Thread.currentThread().getContextClassLoader());
+    }
+
     // =========================================================================
     // Test 1 — Instance method: @Invoker on int add(int x, int y)
     // Validates: Requirements 6.6, 8.1, 8.2
@@ -429,6 +577,147 @@ class RawitAnnotationProcessorIntegrationTest {
             final Object longResult = invoke(zStage, "invoke");
             assertEquals(60, longResult,
                     "bar().x(10).y(20).z(30).invoke() must equal bar(10, 20, 30) = 60");
+        }
+    }
+
+    // =========================================================================
+    // Test 7 — @Constructor on a record produces working staged API
+    // Validates: Requirements 5.1, 5.2, 5.3, 6.1, 6.2
+    // =========================================================================
+
+    @Test
+    void recordConstructor_stagedApi_createsRecordInstance(@TempDir final Path outputDir)
+            throws Exception {
+        final String source =
+                "import rawit.Constructor;\n" +
+                "@Constructor\n" +
+                "public record Point(int x, int y) {}\n";
+
+        try (final URLClassLoader loader = compileAndLoad("Point", source, outputDir)) {
+            final Class<?> pointClass = loader.loadClass("Point");
+
+            // Point.constructor().x(1).y(2).construct() should create Point(1, 2)
+            final Object xStage = pointClass.getMethod("constructor").invoke(null);
+            final Object yStage = invokeInt(xStage, "x", 1);
+            final Object constructStage = invokeInt(yStage, "y", 2);
+            final Object result = invoke(constructStage, "construct");
+
+            assertNotNull(result, "construct() must return a Point instance");
+            assertInstanceOf(pointClass, result, "result must be a Point");
+
+            // Verify component values via accessor methods
+            assertEquals(1, pointClass.getMethod("x").invoke(result), "x must be 1");
+            assertEquals(2, pointClass.getMethod("y").invoke(result), "y must be 2");
+
+            // Round-trip equivalence with direct construction
+            final Object direct = pointClass.getDeclaredConstructor(int.class, int.class)
+                    .newInstance(1, 2);
+            assertEquals(pointClass.getMethod("x").invoke(direct),
+                    pointClass.getMethod("x").invoke(result));
+            assertEquals(pointClass.getMethod("y").invoke(direct),
+                    pointClass.getMethod("y").invoke(result));
+        }
+    }
+
+    // =========================================================================
+    // Test 8 — @Constructor on a record with mixed types (String, int, boolean)
+    // Validates: Requirements 7.1, 7.2
+    // =========================================================================
+
+    @Test
+    void recordConstructor_mixedTypes_stagedApiWorksCorrectly(@TempDir final Path outputDir)
+            throws Exception {
+        final String source =
+                "import rawit.Constructor;\n" +
+                "@Constructor\n" +
+                "public record Config(String name, int port, boolean secure) {}\n";
+
+        try (final URLClassLoader loader = compileAndLoad("Config", source, outputDir)) {
+            final Class<?> configClass = loader.loadClass("Config");
+
+            // Config.constructor().name("server").port(8080).secure(true).construct()
+            final Object nameStage = configClass.getMethod("constructor").invoke(null);
+            final Object portStage = invokeString(nameStage, "name", "server");
+            final Object secureStage = invokeInt(portStage, "port", 8080);
+            final Object constructStage = invokeBoolean(secureStage, "secure", true);
+            final Object result = invoke(constructStage, "construct");
+
+            assertNotNull(result, "construct() must return a Config instance");
+            assertInstanceOf(configClass, result, "result must be a Config");
+
+            // Verify component values via accessor methods
+            assertEquals("server", configClass.getMethod("name").invoke(result),
+                    "name must be 'server'");
+            assertEquals(8080, configClass.getMethod("port").invoke(result),
+                    "port must be 8080");
+            assertEquals(true, configClass.getMethod("secure").invoke(result),
+                    "secure must be true");
+
+            // Round-trip equivalence with direct construction
+            final Object direct = configClass.getDeclaredConstructor(
+                    String.class, int.class, boolean.class).newInstance("server", 8080, true);
+            assertEquals(configClass.getMethod("name").invoke(direct),
+                    configClass.getMethod("name").invoke(result));
+            assertEquals(configClass.getMethod("port").invoke(direct),
+                    configClass.getMethod("port").invoke(result));
+            assertEquals(configClass.getMethod("secure").invoke(direct),
+                    configClass.getMethod("secure").invoke(result));
+        }
+    }
+
+    // =========================================================================
+    // Test 9 — Both record and regular class in same compilation round
+    // Validates: Requirements 8.1, 8.2, 8.3
+    // =========================================================================
+
+    @Test
+    void recordAndClass_sameCompilationRound_bothProduceIndependentApis(
+            @TempDir final Path outputDir) throws Exception {
+        // Use different packages so each gets its own independent Constructor caller class
+        final String recordSource =
+                "package recpkg;\n" +
+                "import rawit.Constructor;\n" +
+                "@Constructor\n" +
+                "public record Coord(int x, int y) {}\n";
+
+        final String classSource =
+                "package clspkg;\n" +
+                "import rawit.Constructor;\n" +
+                "public class Pair {\n" +
+                "    public final int a;\n" +
+                "    public final int b;\n" +
+                "    @Constructor\n" +
+                "    public Pair(int a, int b) { this.a = a; this.b = b; }\n" +
+                "}\n";
+
+        try (final URLClassLoader loader = compileMultipleAndLoad(
+                List.of("recpkg.Coord", "clspkg.Pair"),
+                List.of(recordSource, classSource),
+                outputDir)) {
+
+            // --- Verify the record's staged API ---
+            final Class<?> coordClass = loader.loadClass("recpkg.Coord");
+            final Object coordXStage = coordClass.getMethod("constructor").invoke(null);
+            final Object coordYStage = invokeInt(coordXStage, "x", 10);
+            final Object coordConstructStage = invokeInt(coordYStage, "y", 20);
+            final Object coord = invoke(coordConstructStage, "construct");
+
+            assertNotNull(coord, "construct() must return a Coord instance");
+            assertInstanceOf(coordClass, coord, "result must be a Coord");
+            assertEquals(10, coordClass.getMethod("x").invoke(coord), "x must be 10");
+            assertEquals(20, coordClass.getMethod("y").invoke(coord), "y must be 20");
+
+            // --- Verify the regular class's staged API ---
+            final Class<?> pairClass = loader.loadClass("clspkg.Pair");
+            final Object pairAStage = pairClass.getMethod("constructor").invoke(null);
+            final Object pairBStage = invokeInt(pairAStage, "a", 30);
+            final Object pairConstructStage = invokeInt(pairBStage, "b", 40);
+            final Object pair = invoke(pairConstructStage, "construct");
+
+            assertNotNull(pair, "construct() must return a Pair instance");
+            assertInstanceOf(pairClass, pair, "result must be a Pair");
+            assertEquals(30, pairClass.getField("a").get(pair), "a must be 30");
+            assertEquals(40, pairClass.getField("b").get(pair), "b must be 40");
         }
     }
 }

--- a/src/test/java/rawit/processors/inject/BytecodeInjectorPropertyTest.java
+++ b/src/test/java/rawit/processors/inject/BytecodeInjectorPropertyTest.java
@@ -426,4 +426,143 @@ class BytecodeInjectorPropertyTest {
             deleteDir(tempDir);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Property 7: Bytecode injection produces correct entry point for records
+    // Feature: record-constructor-support, Property 7: Bytecode injection produces correct entry point for records
+    // Validates: Requirements 6.1, 6.2
+    // -------------------------------------------------------------------------
+
+    @Property(tries = 5)
+    @Tag("Feature: record-constructor-support, Property 7: Bytecode injection produces correct entry point for records")
+    void property7_bytecodeInjectionProducesCorrectEntryPointForRecords(
+            @ForAll("paramList") List<Parameter> params
+    ) throws Exception {
+        final String recordName = uniqueClassName("Rec7");
+        final String source = "public record " + recordName + "(" + buildParamList(params) + ") {}";
+
+        final Path tempDir = Files.createTempDirectory("prop7_");
+        try {
+            final Path classFile = compileClass(recordName, source, tempDir);
+
+            // Verify no constructor() method exists before injection
+            assertFalse(readMethods(classFile).getOrDefault("constructor", List.of()).stream()
+                            .anyMatch(d -> d.startsWith("()")),
+                    "record must not have constructor() before injection");
+
+            // Build AnnotatedMethod for a record: isConstructor=true, isConstructorAnnotation=true
+            final AnnotatedMethod method = new AnnotatedMethod(
+                    recordName, "<init>", false, true, true,
+                    params, "V", List.of(), Opcodes.ACC_PUBLIC);
+            final MergeTree tree = linearTree(method);
+
+            final List<String> errors = new ArrayList<>();
+            new BytecodeInjector().inject(classFile, List.of(tree), mockEnv(errors));
+
+            assertTrue(errors.isEmpty(), "no errors expected: " + errors);
+
+            // Verify constructor() method was injected
+            final String descriptor = zeroParamMethodDescriptor(classFile, "constructor");
+            assertNotNull(descriptor, "record must have a parameterless constructor() after injection");
+
+            // Verify it is public static
+            final int access = zeroParamMethodAccess(classFile, "constructor");
+            assertTrue((access & Opcodes.ACC_PUBLIC) != 0, "constructor() must be public");
+            assertTrue((access & Opcodes.ACC_STATIC) != 0, "constructor() must be static");
+
+            // Verify return type is the Constructor caller class (in the same package, i.e. default package here)
+            assertEquals("()LConstructor;", descriptor,
+                    "constructor() must return the Constructor caller class");
+        } finally {
+            deleteDir(tempDir);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Property 8: Injection idempotency for records
+    // Feature: record-constructor-support, Property 8: Injection idempotency
+    // Validates: Requirements 6.3
+    // -------------------------------------------------------------------------
+
+    @Property(tries = 5)
+    @Tag("Feature: record-constructor-support, Property 8: Injection idempotency")
+    void property8_injectionIdempotencyForRecords(
+            @ForAll("paramList") List<Parameter> params
+    ) throws Exception {
+        final String recordName = uniqueClassName("Rec8");
+        // Record that already has a zero-param static constructor() method
+        final String source = "public record " + recordName + "(" + buildParamList(params) + ") {\n"
+                + "    public static " + recordName + " constructor() {\n"
+                + "        return new " + recordName + "(" + buildDefaultArgs(params) + ");\n"
+                + "    }\n"
+                + "}";
+
+        final Path tempDir = Files.createTempDirectory("prop8_");
+        try {
+            final Path classFile = compileClass(recordName, source, tempDir);
+
+            // Verify constructor() already exists before injection
+            assertTrue(readMethods(classFile).getOrDefault("constructor", List.of()).stream()
+                            .anyMatch(d -> d.startsWith("()")),
+                    "record must already have constructor() before injection");
+
+            // Capture the original constructor() descriptor and access flags
+            final String originalDescriptor = zeroParamMethodDescriptor(classFile, "constructor");
+            final int originalAccess = zeroParamMethodAccess(classFile, "constructor");
+            final long originalCount = readMethods(classFile)
+                    .getOrDefault("constructor", List.of()).stream()
+                    .filter(d -> d.startsWith("()")).count();
+
+            // Build AnnotatedMethod for a record: isConstructor=true, isConstructorAnnotation=true
+            final AnnotatedMethod method = new AnnotatedMethod(
+                    recordName, "<init>", false, true, true,
+                    params, "V", List.of(), Opcodes.ACC_PUBLIC);
+            final MergeTree tree = linearTree(method);
+
+            final List<String> errors = new ArrayList<>();
+            new BytecodeInjector().inject(classFile, List.of(tree), mockEnv(errors));
+
+            assertTrue(errors.isEmpty(), "no errors expected: " + errors);
+
+            // Verify the existing constructor() method is unchanged
+            final String afterDescriptor = zeroParamMethodDescriptor(classFile, "constructor");
+            final int afterAccess = zeroParamMethodAccess(classFile, "constructor");
+            final long afterCount = readMethods(classFile)
+                    .getOrDefault("constructor", List.of()).stream()
+                    .filter(d -> d.startsWith("()")).count();
+
+            assertEquals(originalDescriptor, afterDescriptor,
+                    "constructor() descriptor must be unchanged after injection");
+            assertEquals(originalAccess, afterAccess,
+                    "constructor() access flags must be unchanged after injection");
+            assertEquals(originalCount, afterCount,
+                    "number of constructor() overloads must be unchanged — no duplicate injected");
+        } finally {
+            deleteDir(tempDir);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper for building default argument values for record constructor calls
+    // -------------------------------------------------------------------------
+
+    private static String buildDefaultArgs(final List<Parameter> params) {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < params.size(); i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(defaultValueForDescriptor(params.get(i).typeDescriptor()));
+        }
+        return sb.toString();
+    }
+
+    private static String defaultValueForDescriptor(final String descriptor) {
+        return switch (descriptor) {
+            case "I", "J", "S", "B" -> "0";
+            case "Z" -> "false";
+            case "D" -> "0.0";
+            case "F" -> "0.0f";
+            case "C" -> "'a'";
+            default -> "null";
+        };
+    }
 }

--- a/src/test/java/rawit/processors/validation/ElementValidatorPropertyTest.java
+++ b/src/test/java/rawit/processors/validation/ElementValidatorPropertyTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Property-based tests for {@link ElementValidator} validation rules.
@@ -387,5 +388,160 @@ class ElementValidatorPropertyTest {
         assertEquals(1, errorCount,
                 "Expected exactly 1 error for private @Constructor with %d params, got %d. Diagnostics: %s"
                 .formatted(paramTypes.size(), errorCount, diags));
+    }
+
+    // -------------------------------------------------------------------------
+    // Property 2: Validation accepts valid records
+    // -------------------------------------------------------------------------
+
+    @Property(tries = 5)
+    void property2_validRecordWithComponents_producesNoErrors(
+            @ForAll("recordComponentLists") List<String> componentTypes) {
+        // Feature: record-constructor-support, Property 2: Validation accepts valid records
+        // Validates: Requirements 2.1
+
+        String className = uniqueClassName("ValidRecord");
+        String components = buildRecordComponents(componentTypes);
+
+        String source = """
+                import rawit.Constructor;
+                @Constructor
+                public record %s(%s) {}
+                """.formatted(className, components);
+
+        List<Diagnostic<? extends JavaFileObject>> diags = compile(className, source);
+
+        long errorCount = countErrors(diags);
+        assertEquals(0, errorCount,
+                "Expected 0 errors for valid @Constructor on record with %d components, got %d. Diagnostics: %s"
+                .formatted(componentTypes.size(), errorCount, diags));
+    }
+
+    // -------------------------------------------------------------------------
+    // Property 3: Validation rejects non-record types
+    // -------------------------------------------------------------------------
+
+    @Property(tries = 5)
+    void property3_nonRecordType_emitsError(
+            @ForAll("nonRecordTypeKinds") String typeKind) {
+        // Feature: record-constructor-support, Property 3: Validation rejects non-record types
+        // Validates: Requirements 2.3
+
+        String className = uniqueClassName("NonRecord");
+
+        String source = switch (typeKind) {
+            case "class" -> """
+                    import rawit.Constructor;
+                    @Constructor
+                    public class %s {
+                        private final int x;
+                        public %s(int x) { this.x = x; }
+                    }
+                    """.formatted(className, className);
+            case "interface" -> """
+                    import rawit.Constructor;
+                    @Constructor
+                    public interface %s {}
+                    """.formatted(className);
+            case "enum" -> """
+                    import rawit.Constructor;
+                    @Constructor
+                    public enum %s { A, B }
+                    """.formatted(className);
+            default -> throw new IllegalArgumentException("Unknown type kind: " + typeKind);
+        };
+
+        List<Diagnostic<? extends JavaFileObject>> diags = compile(className, source);
+
+        long errorCount = countErrors(diags);
+        assertTrue(errorCount >= 1,
+                "Expected at least 1 error for @Constructor on %s, got %d. Diagnostics: %s"
+                .formatted(typeKind, errorCount, diags));
+        assertTrue(diags.stream()
+                        .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
+                        .anyMatch(d -> d.getMessage(Locale.ROOT).contains("only supported for records")),
+                "Expected error message mentioning 'only supported for records' for @Constructor on %s. Diagnostics: %s"
+                .formatted(typeKind, diags));
+    }
+
+    // -------------------------------------------------------------------------
+    // Property 4: Validation detects constructor() conflict on records
+    // -------------------------------------------------------------------------
+
+    @Property(tries = 5)
+    void property4_recordWithExistingConstructorMethod_emitsConflictError(
+            @ForAll("recordComponentLists") List<String> componentTypes) {
+        // Feature: record-constructor-support, Property 4: Validation detects constructor() conflict on records
+        // Validates: Requirements 2.4
+
+        String className = uniqueClassName("ConflictRecord");
+        String components = buildRecordComponents(componentTypes);
+
+        String source = """
+                import rawit.Constructor;
+                @Constructor
+                public record %s(%s) {
+                    public static %s constructor() {
+                        return new %s(%s);
+                    }
+                }
+                """.formatted(className, components, className, className, buildDefaultValues(componentTypes));
+
+        List<Diagnostic<? extends JavaFileObject>> diags = compile(className, source);
+
+        long errorCount = countErrors(diags);
+        assertTrue(errorCount >= 1,
+                "Expected at least 1 error for @Constructor on record with existing constructor() method, got %d. Diagnostics: %s"
+                .formatted(errorCount, diags));
+        assertTrue(diags.stream()
+                        .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
+                        .anyMatch(d -> d.getMessage(Locale.ROOT).contains("already exists")),
+                "Expected error message mentioning 'already exists' for constructor() conflict. Diagnostics: %s"
+                .formatted(diags));
+    }
+
+    // -------------------------------------------------------------------------
+    // Record-specific arbitraries and helpers
+    // -------------------------------------------------------------------------
+
+    @Provide
+    Arbitrary<List<String>> recordComponentLists() {
+        // 1 to 5 components, each chosen from PARAM_TYPES
+        return Arbitraries.of(PARAM_TYPES)
+                .list()
+                .ofMinSize(1)
+                .ofMaxSize(5);
+    }
+
+    @Provide
+    Arbitrary<String> nonRecordTypeKinds() {
+        return Arbitraries.of("class", "interface", "enum");
+    }
+
+    /** Builds a record component list like "int c0, String c1, long c2". */
+    private String buildRecordComponents(List<String> types) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < types.size(); i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(types.get(i)).append(" c").append(i);
+        }
+        return sb.toString();
+    }
+
+    /** Builds default values for a constructor call, e.g. "0, \"\", 0L, false, 0.0". */
+    private String buildDefaultValues(List<String> types) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < types.size(); i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(switch (types.get(i)) {
+                case "int" -> "0";
+                case "long" -> "0L";
+                case "boolean" -> "false";
+                case "double" -> "0.0";
+                case "String" -> "\"\"";
+                default -> "null";
+            });
+        }
+        return sb.toString();
     }
 }

--- a/src/test/java/rawit/processors/validation/ElementValidatorTest.java
+++ b/src/test/java/rawit/processors/validation/ElementValidatorTest.java
@@ -312,4 +312,107 @@ class ElementValidatorTest {
         assertTrue(errors(diags).isEmpty(),
                 "Expected no errors for a valid @Constructor, got: " + errors(diags));
     }
+
+    // =========================================================================
+    // Requirement 2.1 — @Constructor on a valid record with components → no errors
+    // =========================================================================
+
+    @Test
+    void constructorAnnotation_validRecordWithComponents_noErrors() {
+        // Req 2.1: @Constructor on a record with ≥1 component must produce no errors
+        String source = """
+                import rawit.Constructor;
+                @Constructor
+                public record ValidRecord(int x, int y) {}
+                """;
+
+        List<Diagnostic<? extends JavaFileObject>> diags = compile("ValidRecord", source);
+
+        assertTrue(errors(diags).isEmpty(),
+                "Expected no errors for a valid @Constructor on a record, got: " + errors(diags));
+    }
+
+    // =========================================================================
+    // Requirement 2.2 — @Constructor on a record with zero components → ERROR
+    // =========================================================================
+
+    @Test
+    void constructorAnnotation_zeroComponentRecord_emitsError() {
+        // Req 2.2: @Constructor on a record with zero components must produce an ERROR
+        String source = """
+                import rawit.Constructor;
+                @Constructor
+                public record EmptyRecord() {}
+                """;
+
+        List<Diagnostic<? extends JavaFileObject>> diags = compile("EmptyRecord", source);
+
+        assertTrue(hasErrorContaining(diags, "at least one record component"),
+                "Expected error about requiring at least one record component, got: " + errors(diags));
+    }
+
+    // =========================================================================
+    // Requirement 2.3 — @Constructor on a regular class (not a record) → ERROR
+    // =========================================================================
+
+    @Test
+    void constructorAnnotation_onRegularClass_emitsError() {
+        // Req 2.3: @Constructor on a non-record type must produce an ERROR
+        String source = """
+                import rawit.Constructor;
+                @Constructor
+                public class NotARecord {
+                    private final int x;
+                    public NotARecord(int x) { this.x = x; }
+                }
+                """;
+
+        List<Diagnostic<? extends JavaFileObject>> diags = compile("NotARecord", source);
+
+        assertTrue(hasErrorContaining(diags, "only supported for records"),
+                "Expected error about records only, got: " + errors(diags));
+    }
+
+    // =========================================================================
+    // Requirement 2.3 — @Constructor on an interface → ERROR
+    // =========================================================================
+
+    @Test
+    void constructorAnnotation_onInterface_emitsError() {
+        // Req 2.3: @Constructor on an interface must produce an ERROR
+        String source = """
+                import rawit.Constructor;
+                @Constructor
+                public interface NotARecord {}
+                """;
+
+        List<Diagnostic<? extends JavaFileObject>> diags = compile("NotARecord", source);
+
+        assertTrue(hasErrorContaining(diags, "only supported for records"),
+                "Expected error about records only, got: " + errors(diags));
+    }
+
+    // =========================================================================
+    // Requirement 2.4 — @Constructor on a record with existing constructor() → ERROR
+    // =========================================================================
+
+    @Test
+    void constructorAnnotation_recordWithExistingConstructorMethod_emitsError() {
+        // Req 2.4: @Constructor on a record that already has a zero-param static
+        // method named "constructor" must produce an ERROR about the conflict
+        String source = """
+                import rawit.Constructor;
+                @Constructor
+                public record ConflictRecord(int x) {
+                    public static ConflictRecord constructor() {
+                        return new ConflictRecord(0);
+                    }
+                }
+                """;
+
+        List<Diagnostic<? extends JavaFileObject>> diags = compile("ConflictRecord", source);
+
+        assertTrue(hasErrorContaining(diags, "already exists"),
+                "Expected error about existing 'constructor' method, got: " + errors(diags));
+    }
 }


### PR DESCRIPTION
Adds support for placing @Constructor directly on Java record type declarations. The processor derives canonical constructor parameters from the record's components and generates the same staged construction API.

## Changes

- Expand @Constructor @Target to include ElementType.TYPE
- Add record-type validation in ElementValidator (reject non-records, zero-component records, constructor() conflicts)
- Add TypeElement dispatch fork in RawitAnnotationProcessor.process()
- Implement uildAnnotatedMethodFromRecord() to derive parameters from record components
- Add integration tests, property tests, and sample projects
- Update README with record constructor documentation

## Usage

`java
@Constructor
public record Point(int x, int y) {}

Point p = Point.constructor().x(1).y(2).construct();
`

All 183 tests pass.