### PR TITLE
chore: update sample projects to rawit 0.0.6

### DIFF
--- a/samples/gradle-sample/build.gradle
+++ b/samples/gradle-sample/build.gradle
@@ -12,8 +12,8 @@ repositories {
 }
 
 dependencies {
-    annotationProcessor 'io.github.ronnygunawan:rawit:1.0-SNAPSHOT'
-    compileOnly 'io.github.ronnygunawan:rawit:1.0-SNAPSHOT'
+    annotationProcessor 'io.github.ronnygunawan:rawit:0.0.6'
+    compileOnly 'io.github.ronnygunawan:rawit:0.0.6'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
 }
@@ -37,6 +37,7 @@ task reinjectBytecode(type: JavaCompile) {
     options.compilerArgs += ['-proc:only']
     options.annotationProcessorPath = configurations.annotationProcessor
     options.incremental = false
+    outputs.upToDateWhen { false }
     dependsOn processAnnotations
 }
 

--- a/samples/maven-sample/pom.xml
+++ b/samples/maven-sample/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>io.github.ronnygunawan</groupId>
             <artifactId>rawit</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.0.6</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
- Update Maven sample dependency from 1.0-SNAPSHOT to 0.0.6
- Update Gradle sample dependency from 1.0-SNAPSHOT to 0.0.6
- Fix Gradle reinjectBytecode task skipping with outputs.upToDateWhen { false }

Both sample projects tested and passing.