### PR TITLE
feat: add @Getter demo to sample projects, bump to v0.0.7

### DIFF
--- a/samples/gradle-sample/build.gradle
+++ b/samples/gradle-sample/build.gradle
@@ -12,8 +12,8 @@ repositories {
 }
 
 dependencies {
-    annotationProcessor 'io.github.ronnygunawan:rawit:0.0.6'
-    compileOnly 'io.github.ronnygunawan:rawit:0.0.6'
+    annotationProcessor 'io.github.ronnygunawan:rawit:0.0.7'
+    compileOnly 'io.github.ronnygunawan:rawit:0.0.7'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
 }
@@ -33,8 +33,11 @@ task processAnnotations(type: JavaCompile) {
 task reinjectBytecode(type: JavaCompile) {
     source = sourceSets.main.java
     classpath = sourceSets.main.compileClasspath
-    destinationDirectory = sourceSets.main.java.classesDirectory
-    options.compilerArgs += ['-proc:only']
+    // Use a separate output dir so Gradle doesn't delete main class files.
+    // The processor reads/writes .class files from the classpath (CLASS_OUTPUT),
+    // not from this task's destinationDirectory.
+    destinationDirectory = layout.buildDirectory.dir('classes/java/reinject')
+    options.compilerArgs += ['-proc:only', '-d', sourceSets.main.java.classesDirectory.get().asFile.absolutePath]
     options.annotationProcessorPath = configurations.annotationProcessor
     options.incremental = false
     outputs.upToDateWhen { false }

--- a/samples/gradle-sample/src/main/java/com/example/model/User.java
+++ b/samples/gradle-sample/src/main/java/com/example/model/User.java
@@ -1,0 +1,27 @@
+package com.example.model;
+
+import rawit.Getter;
+
+import java.util.List;
+
+public class User {
+
+    @Getter private String name;
+    @Getter private int age;
+    @Getter private boolean active;
+    @Getter private boolean isVerified;
+    @Getter private Boolean premium;
+    @Getter private static int instanceCount;
+    @Getter private List<String> roles;
+
+    public User(String name, int age, boolean active, boolean isVerified,
+                Boolean premium, List<String> roles) {
+        this.name = name;
+        this.age = age;
+        this.active = active;
+        this.isVerified = isVerified;
+        this.premium = premium;
+        this.roles = roles;
+        instanceCount++;
+    }
+}

--- a/samples/gradle-sample/src/test/java/com/example/RawitSampleTest.java
+++ b/samples/gradle-sample/src/test/java/com/example/RawitSampleTest.java
@@ -3,7 +3,10 @@ package com.example;
 import com.example.model.Calculator;
 import com.example.model.Coord;
 import com.example.model.Point;
+import com.example.model.User;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -34,5 +37,47 @@ class RawitSampleTest {
         Coord c = Coord.constructor().lat(1).lon(2).construct();
         assertEquals(1, c.lat());
         assertEquals(2, c.lon());
+    }
+
+    @Test
+    void getterStringField() {
+        User user = new User("Alice", 30, true, true, true, List.of("admin"));
+        assertEquals("Alice", user.getName());
+    }
+
+    @Test
+    void getterIntField() {
+        User user = new User("Bob", 25, false, false, false, List.of());
+        assertEquals(25, user.getAge());
+    }
+
+    @Test
+    void getterPrimitiveBooleanUsesIsPrefix() {
+        User user = new User("Carol", 28, true, false, null, List.of());
+        assertTrue(user.isActive());
+    }
+
+    @Test
+    void getterPrimitiveBooleanWithIsPrefixKeepsName() {
+        User user = new User("Dave", 35, false, true, null, List.of());
+        assertTrue(user.isVerified());
+    }
+
+    @Test
+    void getterBoxedBooleanUsesGetPrefix() {
+        User user = new User("Eve", 40, false, false, true, List.of());
+        assertEquals(true, user.getPremium());
+    }
+
+    @Test
+    void getterStaticField() {
+        new User("Test", 1, false, false, null, List.of());
+        assertTrue(User.getInstanceCount() > 0);
+    }
+
+    @Test
+    void getterGenericListField() {
+        User user = new User("Frank", 22, false, false, null, List.of("user", "editor"));
+        assertEquals(List.of("user", "editor"), user.getRoles());
     }
 }

--- a/samples/maven-sample/pom.xml
+++ b/samples/maven-sample/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>io.github.ronnygunawan</groupId>
             <artifactId>rawit</artifactId>
-            <version>0.0.6</version>
+            <version>0.0.7</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/samples/maven-sample/src/main/java/com/example/model/User.java
+++ b/samples/maven-sample/src/main/java/com/example/model/User.java
@@ -1,0 +1,27 @@
+package com.example.model;
+
+import rawit.Getter;
+
+import java.util.List;
+
+public class User {
+
+    @Getter private String name;
+    @Getter private int age;
+    @Getter private boolean active;
+    @Getter private boolean isVerified;
+    @Getter private Boolean premium;
+    @Getter private static int instanceCount;
+    @Getter private List<String> roles;
+
+    public User(String name, int age, boolean active, boolean isVerified,
+                Boolean premium, List<String> roles) {
+        this.name = name;
+        this.age = age;
+        this.active = active;
+        this.isVerified = isVerified;
+        this.premium = premium;
+        this.roles = roles;
+        instanceCount++;
+    }
+}

--- a/samples/maven-sample/src/test/java/com/example/RawitSampleTest.java
+++ b/samples/maven-sample/src/test/java/com/example/RawitSampleTest.java
@@ -3,7 +3,10 @@ package com.example;
 import com.example.model.Calculator;
 import com.example.model.Coord;
 import com.example.model.Point;
+import com.example.model.User;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -34,5 +37,47 @@ class RawitSampleTest {
         Coord c = Coord.constructor().lat(1).lon(2).construct();
         assertEquals(1, c.lat());
         assertEquals(2, c.lon());
+    }
+
+    @Test
+    void getterStringField() {
+        User user = new User("Alice", 30, true, true, true, List.of("admin"));
+        assertEquals("Alice", user.getName());
+    }
+
+    @Test
+    void getterIntField() {
+        User user = new User("Bob", 25, false, false, false, List.of());
+        assertEquals(25, user.getAge());
+    }
+
+    @Test
+    void getterPrimitiveBooleanUsesIsPrefix() {
+        User user = new User("Carol", 28, true, false, null, List.of());
+        assertTrue(user.isActive());
+    }
+
+    @Test
+    void getterPrimitiveBooleanWithIsPrefixKeepsName() {
+        User user = new User("Dave", 35, false, true, null, List.of());
+        assertTrue(user.isVerified());
+    }
+
+    @Test
+    void getterBoxedBooleanUsesGetPrefix() {
+        User user = new User("Eve", 40, false, false, true, List.of());
+        assertEquals(true, user.getPremium());
+    }
+
+    @Test
+    void getterStaticField() {
+        new User("Test", 1, false, false, null, List.of());
+        assertTrue(User.getInstanceCount() > 0);
+    }
+
+    @Test
+    void getterGenericListField() {
+        User user = new User("Frank", 22, false, false, null, List.of("user", "editor"));
+        assertEquals(List.of("user", "editor"), user.getRoles());
     }
 }


### PR DESCRIPTION
Adds \@Getter\ demonstration to both Maven and Gradle sample projects using the newly published v0.0.7.

- New \User\ model class with \@Getter\ fields: String, int, primitive boolean, boolean with is-prefix, boxed Boolean, static int, and generic \List<String>\
- 7 new test cases covering all getter naming conventions and field types
- Bumps rawit dependency from 0.0.6 to 0.0.7
- Fixes Gradle \einjectBytecode\ task deleting \.class\ files for \@Getter\-only classes (uses separate output dir so Gradle doesn't clean main classes)