### PR TITLE
chore: update sample projects to rawit v0.0.8

### DIFF
--- a/samples/gradle-sample/build.gradle
+++ b/samples/gradle-sample/build.gradle
@@ -12,8 +12,8 @@ repositories {
 }
 
 dependencies {
-    annotationProcessor 'io.github.ronnygunawan:rawit:1.0-SNAPSHOT'
-    compileOnly 'io.github.ronnygunawan:rawit:1.0-SNAPSHOT'
+    annotationProcessor 'io.github.ronnygunawan:rawit:0.0.8'
+    compileOnly 'io.github.ronnygunawan:rawit:0.0.8'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
 }

--- a/samples/maven-sample/pom.xml
+++ b/samples/maven-sample/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>io.github.ronnygunawan</groupId>
             <artifactId>rawit</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.0.8</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Updates the rawit dependency version in both sample projects from 1.0-SNAPSHOT to 0.0.8 to match the latest release.

**Changes:**
- samples/maven-sample/pom.xml: 1.0-SNAPSHOT → 0.0.8
- samples/gradle-sample/build.gradle: 1.0-SNAPSHOT → 0.0.8